### PR TITLE
Run eslint during CI build process

### DIFF
--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -23,7 +23,15 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${1:-}" = "--help" ]; then
         usage
     else
+        pushd src/app
+
+        # Run linter
+        ./node_modules/react-scripts/node_modules/.bin/eslint \
+         src/ --ext .js --ext .jsx --max-warnings=0
+
         # Build static asset bundle
-        pushd src/app && yarn build && popd
+        yarn build
+
+        popd
     fi
 fi


### PR DESCRIPTION
## Overview

Any errors or warnings will fail the build.

Connects to #14 

### Demo

See build log at https://app.netlify.com/sites/ism-watershed-wellness-snapshot/deploys/5c1be03d9bb0870008680e3c

## Testing Instructions

- View the build log for this PR on Netlify, and verify it failed because of lint.