### PR TITLE
Implement custom map style and initial view

### DIFF
--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import ReactMapGL from 'react-map-gl';
+import ReactMapGL, { NavigationControl } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { connect } from 'react-redux';
 
@@ -16,7 +16,16 @@ class GLMap extends Component {
                     {...this.props.viewport}
                     onViewportChange={this.props.updateViewport}
                     mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_API_KEY}
-                />
+                    mapStyle={'mapbox://styles/alash/cjpconu8b0sas2qn5rx51uog8'}
+                    interactive={false}
+                    doubleClickZoom={false}
+                    dragPan={false}
+                    dragRotate={false}
+                    touchZoomRotate={false}
+                    scrollZoom={false}
+                >
+                    <NavigationControl showZoom={false} />
+                </ReactMapGL>
             </div>
         );
     }

--- a/src/app/src/Map.scss
+++ b/src/app/src/Map.scss
@@ -2,3 +2,12 @@
   width: 100%;
   height: 100%;
 }
+
+.mapboxgl-ctrl-compass {
+  position: absolute;
+  bottom: 20px;
+  right: 40px;
+  border-radius: 20px;
+  border: 1px solid #D3ECEE !important;
+}
+

--- a/src/app/src/map.reducers.js
+++ b/src/app/src/map.reducers.js
@@ -2,9 +2,11 @@ import { createViewportReducer } from 'redux-map-gl';
 
 const initialState = {
     viewport: {
-        latitude: 37.7577,
-        longitude: -122.4376,
-        zoom: 8,
+        latitude: 40.2161,
+        longitude: -75.0726,
+        zoom: 9,
+        bearing: -30,
+        pitch: 60,
     },
 };
 


### PR DESCRIPTION
## Overview

Makes use of the style created by @alexelash, and matches the initial map view to that of the wireframes. Also makes the map not interactive (as designed) and adds the navigation control.

Connects #23

### Demo

Wireframes:

![image](https://user-images.githubusercontent.com/1042475/50908421-af469880-13f7-11e9-9d1b-fa8ed45988e6.png)

Screenshot of app:

![image](https://user-images.githubusercontent.com/1042475/50908444-b8376a00-13f7-11e9-8720-107f82457a7a.png)

# Notes

Follow-up: #25 

## Testing Instructions

- Visit the app and verify the map looks roughly like the map in the wireframes. 
- Verify that the map is not interactive.