### PR TITLE
Add sensor markers and map interactions

### DIFF
--- a/src/app/src/BackToMapButton.js
+++ b/src/app/src/BackToMapButton.js
@@ -1,0 +1,14 @@
+import React from 'react';
+
+import { initialViewportState } from './map.reducers';
+import './BackToMapButton.scss';
+
+export default function BackToMapButton(props) {
+    const handleOnClick = () => props.handleOnClick(initialViewportState);
+
+    return (
+        <div id='back-to-map' onClick={handleOnClick}>
+            Back to map
+        </div>
+    );
+}

--- a/src/app/src/BackToMapButton.scss
+++ b/src/app/src/BackToMapButton.scss
@@ -1,0 +1,10 @@
+#back-to-map {
+  position: absolute;
+  bottom: 45px;
+  left: 10px;
+  background-color: snow;
+  padding: 10px;
+  border-radius: 15px;
+  border: 1px solid bisque;
+  cursor: pointer;
+}

--- a/src/app/src/SensorMarker.js
+++ b/src/app/src/SensorMarker.js
@@ -1,0 +1,39 @@
+import React from 'react';
+
+const ICON = `M20.2,15.7L20.2,15.7c1.1-1.6,1.8-3.6,1.8-5.7c0-5.6-4.5-10-10-10S2,4.5,2,10c0,2,0.6,3.9,1.6,5.4c0,0.1,0.1,0.2,0.2,0.3
+  c0,0,0.1,0.1,0.1,0.2c0.2,0.3,0.4,0.6,0.7,0.9c2.6,3.1,7.4,7.6,7.4,7.6s4.8-4.5,7.4-7.5c0.2-0.3,0.5-0.6,0.7-0.9
+  C20.1,15.8,20.2,15.8,20.2,15.7z`;
+
+const pinStyle = {
+    cursor: 'pointer',
+    fill: '#DDD7C0',
+    stroke: 'none',
+};
+
+export default function SensorMarker(props) {
+    const { sensor, size = 20 } = props;
+
+    const handleOnClick = () => {
+        props.handleOnClick({
+            latitude: sensor.geometry.coordinates[1],
+            longitude: sensor.geometry.coordinates[0],
+            zoom: 13,
+            bearing: 0,
+            pitch: 0,
+        });
+    };
+
+    return (
+        <svg
+            height={size}
+            viewBox='0 0 24 24'
+            style={{
+                ...pinStyle,
+                transform: `translate(${-size / 2}px,${-size}px)`,
+            }}
+            onClick={handleOnClick}
+        >
+            <path d={ICON} />
+        </svg>
+    );
+}

--- a/src/app/src/index.js
+++ b/src/app/src/index.js
@@ -8,10 +8,12 @@ import './index.css';
 import App from './App';
 import * as serviceWorker from './serviceWorker';
 import * as actions from './actions';
+import { toggleBackToMapButton } from './map.actions';
 import configureStore from './store';
 
 const store = configureStore();
 assignAll(actions, store);
+assignAll([toggleBackToMapButton], store);
 
 const renderWithHotReloading = Component => {
     return ReactDOM.render(

--- a/src/app/src/map.actions.js
+++ b/src/app/src/map.actions.js
@@ -1,3 +1,8 @@
 import { onChangeViewport } from 'redux-map-gl';
+import { createAction } from 'redux-act';
 
-export default onChangeViewport;
+export const toggleBackToMapButton = createAction(
+    'Toggle back to map button visibility'
+);
+
+export { onChangeViewport };

--- a/src/app/src/map.reducers.js
+++ b/src/app/src/map.reducers.js
@@ -1,13 +1,37 @@
-import { createViewportReducer } from 'redux-map-gl';
+import { createReducer } from 'redux-act';
+import enhanceMapReducer from 'redux-map-gl';
+import update from 'immutability-helper';
 
-const initialState = {
-    viewport: {
-        latitude: 40.2161,
-        longitude: -75.0726,
-        zoom: 9,
-        bearing: -30,
-        pitch: 60,
-    },
+import { toggleBackToMapButton } from './map.actions';
+
+// Map-related state
+const initialMapState = {
+    isBackToMapButtonVisible: false,
 };
 
-export default createViewportReducer(initialState);
+// State specific to and required by MapBoxGL
+export const initialViewportState = {
+    latitude: 40.2161,
+    longitude: -75.0726,
+    zoom: 9,
+    bearing: -30,
+    pitch: 60,
+};
+
+// Map-related reducer
+const mapReducer = createReducer(
+    {
+        [toggleBackToMapButton]: state =>
+            update(state, {
+                isBackToMapButtonVisible: {
+                    $set: !state.isBackToMapButtonVisible,
+                },
+            }),
+    },
+    initialMapState
+);
+
+// Add MapBoxGL-specific reducer to map reducer
+const enhancedMapReducer = enhanceMapReducer(mapReducer, initialViewportState);
+
+export default enhancedMapReducer;

--- a/src/app/src/sensors.json
+++ b/src/app/src/sensors.json
@@ -1,0 +1,47 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "Location": "Tinicum",
+        "Name": "USGS 01475548 Cobbs Creek at Mt. Moriah Cemetery, Philadelphia"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -75.23767948150635,
+          39.93334294384733
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Location": "Wissahickon",
+        "Name": "USGS 01474000 Wissahickon Creek at Mouth, Philadelphia, PA"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -75.20681262016296,
+          40.01526962136133
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "Location": "Delaware Water Gap",
+        "Name": "USGS 01438500 Delaware River at Montague NJ"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -74.79513645172119,
+          41.30847065369865
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Overview

Adds markers for sensors to the map. Clicking a marker transitions the map to viewport centered around the marker in anticipation of the selected marker view. A "back to map" button is also added in this view.
Clicking it transitions the map back to the initial viewport.

Connects to #27

### Demo

*Demo gif is low-res and short due to large file size.*

![jan-10-2019 12-48-29](https://user-images.githubusercontent.com/1042475/50986912-120e6180-14d6-11e9-85cc-032c21313e7e.gif)

## Testing Instructions

- Click a map marker. Verify the map zooms to that marker and that the "back to map" button appears.
- Click the "back to map" button. Verify the map returns to the initial position.