### PR TITLE
Prevent app from crashing on iPad

### DIFF
--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -51,7 +51,7 @@ class GLMap extends Component {
                     {...this.props.mapstate}
                     onViewportChange={this.props.updateViewport}
                     mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_API_KEY}
-                    mapStyle={'mapbox://styles/alash/cjpconu8b0sas2qn5rx51uog8'}
+                    mapStyle={'mapbox://styles/alash/cjqy7v5yn04ra2rmhy72tvnhc'}
                     interactive={false}
                     doubleClickZoom={false}
                     dragPan={false}


### PR DESCRIPTION
## Overview

Utilize a version of the basemap that does not have the terrain/hillshade layer. This layer was causing the application to crash on iPads, which is the target device for this project. The crash seems to be caused by the issues described here: mapbox/mapbox-gl-js#4695

Connects #31 

## Testing Instructions

- Visit the [deploy preview](https://deploy-preview-34--ism-watershed-wellness-snapshot.netlify.com/) site on an iPad.
- Click the sensor markers/back to map button, and verify the app doesn't crash after a few transitions.