### PR TITLE
Use basemap hosted on Azavea Mapbox account

### DIFF
--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -48,7 +48,9 @@ class GLMap extends Component {
                     {...this.props.mapstate}
                     onViewportChange={this.props.updateViewport}
                     mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_API_KEY}
-                    mapStyle={'mapbox://styles/alash/cjqy7v5yn04ra2rmhy72tvnhc'}
+                    mapStyle={
+                        'mapbox://styles/azavea/cjrky7g714qpy2spmyk5u9llq'
+                    }
                     interactive={false}
                     doubleClickZoom={false}
                     dragPan={false}


### PR DESCRIPTION
## Overview

The style was exported from the previous account and is unmodified.

Connects #28

### Notes

There is also now a API key specifically for the project, which can be retrieved by logging into the Azavea Mapbox account.

## Testing Instructions

- Visit the site and ensure the basemap works as before.