### PR TITLE
Add custom sensor markers

### DIFF
--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -30,6 +30,9 @@ class GLMap extends Component {
                 key={`marker-${index}`}
                 longitude={sensor.geometry.coordinates[0]}
                 latitude={sensor.geometry.coordinates[1]}
+                anchor='bottom'
+                offsetLeft={-40}
+                offsetTop={-108}
             >
                 <SensorMarker
                     sensor={sensor}

--- a/src/app/src/SensorMarker.js
+++ b/src/app/src/SensorMarker.js
@@ -1,19 +1,10 @@
 import React from 'react';
 
 import { selectSensor } from './app.actions';
-
-const ICON = `M20.2,15.7L20.2,15.7c1.1-1.6,1.8-3.6,1.8-5.7c0-5.6-4.5-10-10-10S2,4.5,2,10c0,2,0.6,3.9,1.6,5.4c0,0.1,0.1,0.2,0.2,0.3
-  c0,0,0.1,0.1,0.1,0.2c0.2,0.3,0.4,0.6,0.7,0.9c2.6,3.1,7.4,7.6,7.4,7.6s4.8-4.5,7.4-7.5c0.2-0.3,0.5-0.6,0.7-0.9
-  C20.1,15.8,20.2,15.8,20.2,15.7z`;
-
-const pinStyle = {
-    cursor: 'pointer',
-    fill: '#DDD7C0',
-    stroke: 'none',
-};
+import positiveFishIcon from './img/fish_positive.svg';
 
 export default function SensorMarker(props) {
-    const { sensor, selectedSensor, size = 20 } = props;
+    const { sensor, selectedSensor } = props;
 
     // Makes sure the marker is centered in the visible
     // portion of the map, since half of the map is
@@ -34,16 +25,21 @@ export default function SensorMarker(props) {
     };
 
     return (
-        <svg
-            height={size}
-            viewBox='0 0 24 24'
-            style={{
-                ...pinStyle,
-                transform: `translate(${-size / 2}px,${-size}px)`,
-            }}
-            onClick={handleOnClick}
-        >
-            <path d={ICON} />
-        </svg>
+        <div onClick={handleOnClick}>
+            <div className='marker marker--positive'>
+                <div className='marker__inner'>
+                    <div className='marker__content'>
+                        <div className='marker__level' />
+                        <div className='marker__symbol'>
+                            <img
+                                className='marker__image'
+                                src={positiveFishIcon}
+                                alt='Sensor marker'
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     );
 }

--- a/src/app/src/sass/01_settings/_variables.scss
+++ b/src/app/src/sass/01_settings/_variables.scss
@@ -22,7 +22,7 @@ $button-background-secondary: $brand-aqua-light;
 /* ------------------------------------*\
     #MARKERS
 \*------------------------------------ */
-$marker-width: 9rem;
+$marker-width: 8rem;
 
 /* ------------------------------------*\
     #MODAL


### PR DESCRIPTION
## Overview

Implement the custom HTML markers for the sensor locations. The color and fish icon will change depending on the water quality reported by the actual sensors. This will be implemented in #43.

Connects #40

### Demo

![image](https://user-images.githubusercontent.com/1042475/52236185-24d94380-2894-11e9-9fa1-39a8c1d45bae.png)

### Notes

The map attribution and MapBox logo appear to be off, but they appear in the correct spot on an iPad Pro. Design revisions will be made in #45 

## Testing Instructions

- Visit the map and verify that the custom markers are used on the map.