### PR TITLE
Use compact attribution control

### DIFF
--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -6,6 +6,7 @@ import ReactMapGL, {
 } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { connect } from 'react-redux';
+import mapboxgl from 'mapbox-gl';
 
 import { updateViewport } from './map.actions';
 import SensorMarker from './SensorMarker';
@@ -13,6 +14,17 @@ import BackToMapButton from './BackToMapButton';
 import { toggleBackToMapButton } from './map.actions';
 
 class GLMap extends Component {
+    constructor() {
+        super();
+
+        this.mapRef = React.createRef();
+    }
+
+    componentDidMount() {
+        const map = this.mapRef.current.getMap();
+        map.addControl(new mapboxgl.AttributionControl({ compact: true }));
+    }
+
     goToLocation = options => {
         toggleBackToMapButton();
 
@@ -46,6 +58,7 @@ class GLMap extends Component {
             <div id='map' className='map'>
                 <ReactMapGL
                     {...this.props.mapstate}
+                    ref={this.mapRef}
                     onViewportChange={this.props.updateViewport}
                     mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_API_KEY}
                     mapStyle={
@@ -58,6 +71,7 @@ class GLMap extends Component {
                     touchRotate={false}
                     touchZoom={false}
                     scrollZoom={false}
+                    attributionControl={false}
                 >
                     <NavigationControl showZoom={false} />
                     {Object.values(this.props.sensors.features).map(


### PR DESCRIPTION
## Overview

Conserves some screen space, which is especially helpful in the sensor overview view. Previously, the attribution was colliding with the MapBox logo when view on an iPad.

Connects #51

### Demo

**Before**
![image](https://user-images.githubusercontent.com/1042475/52305233-a5ff0c00-2962-11e9-97a6-6e7740429454.png)

**After**
![image](https://user-images.githubusercontent.com/1042475/52305254-b0210a80-2962-11e9-894a-ad290d08df8b.png)

## Note

The attribution and Mapbox logo are currently mispositioned when viewing in the browser.

## Testing Instructions

- Ensure the attribution control is compact by default, and expands when hovered over.