### PR TITLE
Wire up ratings and sensor data feed to frontend

### DIFF
--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -54,7 +54,9 @@ class App extends Component {
                 {selectedSensor !== null ? (
                     <SensorOverview
                         sensor={selectedSensor}
-                        sensorRatings={sensorRatings[selectedSensor.properties.Id]}
+                        sensorRatings={
+                            sensorRatings[selectedSensor.properties.Id]
+                        }
                         sensorData={sensorData[selectedSensor.properties.Id]}
                         isSensorModalDisplayed={isSensorModalDisplayed}
                     />

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -9,7 +9,6 @@ import SensorOverview from './SensorOverview';
 
 import { POLLING_INTERVAL } from './constants';
 import { pollSensor } from './app.actions';
-import { getSensorByProp } from './sensorUtils';
 
 class App extends Component {
     componentDidMount() {
@@ -32,13 +31,14 @@ class App extends Component {
             isIntroVisible,
             selectedSensor,
             isSensorModalDisplayed,
+            sensorRatings,
+            sensorData,
         } = this.props;
         let containerClassName = isIntroVisible
             ? 'main p-intro'
             : selectedSensor
             ? 'main p-detail'
             : 'main p-landing';
-        const sensorData = getSensorByProp('Location', selectedSensor);
         if (isSensorModalDisplayed) {
             containerClassName += ' modal-is-open';
         }
@@ -53,7 +53,9 @@ class App extends Component {
                 <GLMap />
                 {selectedSensor !== null ? (
                     <SensorOverview
-                        sensor={sensorData}
+                        sensor={selectedSensor}
+                        sensorRatings={sensorRatings[selectedSensor.properties.Id]}
+                        sensorData={sensorData[selectedSensor.properties.Id]}
                         isSensorModalDisplayed={isSensorModalDisplayed}
                     />
                 ) : null}
@@ -66,7 +68,9 @@ function mapStateToProps(state) {
     return {
         isIntroVisible: state.app.isIntroVisible,
         selectedSensor: state.app.selectedSensor,
-        sensors: state.map.sensors,
+        sensors: state.app.sensors,
+        sensorRatings: state.app.sensorRatings,
+        sensorData: state.app.sensorData,
         isSensorModalDisplayed: state.app.isSensorModalDisplayed,
     };
 }

--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -37,6 +37,13 @@ class GLMap extends Component {
     };
 
     renderCityMarkers = (sensor, index) => {
+        const {
+            selectedSensor,
+            sensorRatings,
+        } = this.props;
+        const overallRating = sensorRatings[sensor.properties.Id]
+            ? sensorRatings[sensor.properties.Id].OVERALL_RATING
+            : null;
         return (
             <Marker
                 key={`marker-${index}`}
@@ -48,7 +55,8 @@ class GLMap extends Component {
             >
                 <SensorMarker
                     sensor={sensor}
-                    selectedSensor={this.props.selectedSensor}
+                    selectedSensor={selectedSensor}
+                    sensorOverallRating={overallRating}
                     size={50}
                     handleOnClick={this.goToLocation}
                 />
@@ -94,6 +102,7 @@ function mapStateToProps(state) {
         mapstate: state.map.viewport,
         showBackToMapButton: state.map.isBackToMapButtonVisible,
         sensors: state.app.sensors,
+        sensorRatings: state.app.sensorRatings,
         selectedSensor: state.app.selectedSensor,
     };
 }

--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -93,7 +93,7 @@ function mapStateToProps(state) {
     return {
         mapstate: state.map.viewport,
         showBackToMapButton: state.map.isBackToMapButtonVisible,
-        sensors: state.map.sensors,
+        sensors: state.app.sensors,
         selectedSensor: state.app.selectedSensor,
     };
 }

--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -37,10 +37,7 @@ class GLMap extends Component {
     };
 
     renderCityMarkers = (sensor, index) => {
-        const {
-            selectedSensor,
-            sensorRatings,
-        } = this.props;
+        const { selectedSensor, sensorRatings } = this.props;
         const overallRating = sensorRatings[sensor.properties.Id]
             ? sensorRatings[sensor.properties.Id].OVERALL_RATING
             : null;

--- a/src/app/src/SensorDetails.js
+++ b/src/app/src/SensorDetails.js
@@ -10,23 +10,20 @@ import {
 } from './sensorUtils';
 import { VARIABLES, VARIABLE_DETAILS } from './constants';
 
-
 export default function SensorDetail({ sensor, sensorRatings, sensorData }) {
     const variableSections = VARIABLES.map(v => {
         const {
             properties: { HealthyRanges },
         } = sensor;
-    
-        const {
-            unit,
-            name, 
-            description,
-        } = VARIABLE_DETAILS[v];
+
+        const { unit, name, description } = VARIABLE_DETAILS[v];
 
         const variableRating = sensorRatings[v];
         const score = sensorData[v];
         const scoreWithUnit = `${score} ${unit}`;
-        const range = `${HealthyRanges[v].lower}-${HealthyRanges[v].upper} ${unit}`;
+        const range = `${HealthyRanges[v].lower}-${
+            HealthyRanges[v].upper
+        } ${unit}`;
 
         return (
             <section className='section' key={v}>
@@ -35,11 +32,13 @@ export default function SensorDetail({ sensor, sensorRatings, sensorData }) {
                     <p className='section__description'>
                         Between {range} is considered a healthy range
                     </p>
-                    <p className='section__body'>
-                        {description}
-                    </p>
+                    <p className='section__body'>{description}</p>
                 </div>
-                <div className={`section__illustration indicator-reading indicator-reading--${getClassNameFromVariableRating(variableRating)}`}>
+                <div
+                    className={`section__illustration indicator-reading indicator-reading--${getClassNameFromVariableRating(
+                        variableRating
+                    )}`}
+                >
                     <img
                         className='indicator-reading__fish'
                         src={getFishIconForVariableRating(variableRating)}

--- a/src/app/src/SensorDetails.js
+++ b/src/app/src/SensorDetails.js
@@ -2,15 +2,58 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import closeIcon from './img/times.svg';
-import positiveFishIcon from './img/fish_positive.svg';
-import positiveBackground from './img/health_background_positive.svg';
-import warningFishIcon from './img/fish_warning.svg';
-import warningBackground from './img/health_background_warning.svg';
-import negativeFishIcon from './img/fish_negative.svg';
-import negativeBackground from './img/health_background_negative.svg';
 import { hideSensorModal } from './app.actions';
+import { getFishIcon, getFishBackground, getRatingClassName } from './sensorUtils';
+import { VARIABLES, VARIABLE_DETAILS } from './constants';
 
-export default function SensorDetail({ sensor }) {
+
+export default function SensorDetail({ sensor, sensorRatings, sensorData }) {
+    const variableSections = VARIABLES.map(v => {
+        const {
+            properties: { HealthyRanges },
+        } = sensor;
+    
+        const {
+            unit,
+            name, 
+            description,
+        } = VARIABLE_DETAILS[v];
+
+        const rating = sensorRatings[v];
+        const score = sensorData[v];
+        const scoreWithUnit = `${score} ${unit}`;
+        const range = `${HealthyRanges[v].lower}-${HealthyRanges[v].upper} ${unit}`;
+
+        return (
+            <section className='section' key={v}>
+                <div className='section__content'>
+                    <h3 className='section__title'>{name}</h3>
+                    <p className='section__description'>
+                        Between {range} is considered a healthy range
+                    </p>
+                    <p className='section__body'>
+                        {description}
+                    </p>
+                </div>
+                <div className={`section__illustration indicator-reading indicator-reading--${getRatingClassName(rating)}`}>
+                    <img
+                        className='indicator-reading__fish'
+                        src={getFishIcon(rating)}
+                        alt=''
+                    />
+                    <div className='indicator-reading__reading'>
+                        {scoreWithUnit}
+                    </div>
+                    <img
+                        className='indicator-reading__background'
+                        src={getFishBackground(rating)}
+                        alt=''
+                    />
+                </div>
+            </section>
+        );
+    });
+
     return ReactDOM.createPortal(
         <div id='modal-1' className='modal is-open'>
             <div
@@ -47,156 +90,7 @@ export default function SensorDetail({ sensor }) {
                 </header>
 
                 <div id='modal-1-content' className='modal__content'>
-                    <section className='section'>
-                        <div className='section__content'>
-                            <h3 className='section__title'>Turbidity</h3>
-                            <p className='section__description'>
-                                Between 1-50 NTU is considered a healthy range
-                            </p>
-                            <p className='section__body'>
-                                Turbidity is a measurement of the cloudiness in
-                                a body of water. This cloudiness is caused by
-                                the presense of particles that can be invisible
-                                to the human eye.
-                            </p>
-                        </div>
-                        <div className='section__illustration indicator-reading indicator-reading--positive'>
-                            <img
-                                className='indicator-reading__fish'
-                                src={positiveFishIcon}
-                                alt=''
-                            />
-                            <div className='indicator-reading__reading'>
-                                43 NTU
-                            </div>
-                            <img
-                                className='indicator-reading__background'
-                                src={positiveBackground}
-                                alt=''
-                            />
-                        </div>
-                    </section>
-
-                    <section className='section'>
-                        <div className='section__content'>
-                            <h3 className='section__title'>Dissolved Oxygen</h3>
-                            <p className='section__description'>
-                                Between 2-24 mg/L is considered a healthy range
-                            </p>
-                            <p className='section__body'>
-                                A measure of the concentration of oxygen
-                                dissolved in a body of water, relative to the
-                                maximum concentration.
-                            </p>
-                        </div>
-                        <div className='section__illustration indicator-reading indicator-reading--positive'>
-                            <img
-                                className='indicator-reading__fish'
-                                src={positiveFishIcon}
-                                alt=''
-                            />
-                            <div className='indicator-reading__reading'>
-                                3 mg/L
-                            </div>
-                            <img
-                                className='indicator-reading__background'
-                                src={positiveBackground}
-                                alt=''
-                            />
-                        </div>
-                    </section>
-
-                    <section className='section'>
-                        <div className='section__content'>
-                            <h3 className='section__title'>pH</h3>
-                            <p className='section__description'>
-                                Between 6.5-8.5pH is considered a healthy range
-                            </p>
-                            <p className='section__body'>
-                                pH is a quantitative measure of the acidity
-                                (below 7.0pH) or basicity (above 7.0pH) in a
-                                body of water.
-                            </p>
-                        </div>
-                        <div className='section__illustration indicator-reading indicator-reading--positive'>
-                            <img
-                                className='indicator-reading__fish'
-                                src={positiveFishIcon}
-                                alt=''
-                            />
-                            <div className='indicator-reading__reading'>
-                                8.35 pH
-                            </div>
-                            <img
-                                className='indicator-reading__background'
-                                src={positiveBackground}
-                                alt=''
-                            />
-                        </div>
-                    </section>
-
-                    <section className='section'>
-                        <div className='section__content'>
-                            <h3 className='section__title'>
-                                Water temperature
-                            </h3>
-                            <p className='section__description'>
-                                Between 40-87°F is considered a healthy range
-                            </p>
-                            <p className='section__body'>
-                                Water temperature affects the growth and
-                                reproduction of living organisms as well as
-                                water density.
-                            </p>
-                        </div>
-                        <div className='section__illustration indicator-reading indicator-reading--negative'>
-                            <img
-                                className='indicator-reading__fish'
-                                src={negativeFishIcon}
-                                alt=''
-                            />
-                            <div className='indicator-reading__reading'>
-                                95°F
-                            </div>
-                            <img
-                                className='indicator-reading__background'
-                                src={negativeBackground}
-                                alt=''
-                            />
-                        </div>
-                    </section>
-
-                    <section className='section'>
-                        <div className='section__content'>
-                            <h3 className='section__title'>
-                                Index of Biological Integrity
-                            </h3>
-                            <p className='section__description'>
-                                Aenean lacinia bibendum nulla sed consectetur
-                            </p>
-                            <p className='section__body'>
-                                Index of Biological Integrity (IBI) is a
-                                scientific measurement of stream health through
-                                biological criteria, such as the presence of
-                                animal life.
-                            </p>
-                        </div>
-                        <div className='section__illustration indicator-reading indicator-reading--warning'>
-                            <img
-                                className='indicator-reading__fish'
-                                src={warningFishIcon}
-                                alt=''
-                            />
-                            <div className='indicator-reading__reading'>
-                                Moderate
-                            </div>
-                            <img
-                                className='indicator-reading__background'
-                                src={warningBackground}
-                                alt=''
-                            />
-                        </div>
-                    </section>
+                    {variableSections}
                 </div>
 
                 <footer className='modal__footer'>

--- a/src/app/src/SensorDetails.js
+++ b/src/app/src/SensorDetails.js
@@ -3,7 +3,11 @@ import ReactDOM from 'react-dom';
 
 import closeIcon from './img/times.svg';
 import { hideSensorModal } from './app.actions';
-import { getFishIcon, getFishBackground, getRatingClassName } from './sensorUtils';
+import {
+    getFishIconForVariableRating,
+    getFishBackgroundForVariableRating,
+    getClassNameFromVariableRating,
+} from './sensorUtils';
 import { VARIABLES, VARIABLE_DETAILS } from './constants';
 
 
@@ -19,7 +23,7 @@ export default function SensorDetail({ sensor, sensorRatings, sensorData }) {
             description,
         } = VARIABLE_DETAILS[v];
 
-        const rating = sensorRatings[v];
+        const variableRating = sensorRatings[v];
         const score = sensorData[v];
         const scoreWithUnit = `${score} ${unit}`;
         const range = `${HealthyRanges[v].lower}-${HealthyRanges[v].upper} ${unit}`;
@@ -35,10 +39,10 @@ export default function SensorDetail({ sensor, sensorRatings, sensorData }) {
                         {description}
                     </p>
                 </div>
-                <div className={`section__illustration indicator-reading indicator-reading--${getRatingClassName(rating)}`}>
+                <div className={`section__illustration indicator-reading indicator-reading--${getClassNameFromVariableRating(variableRating)}`}>
                     <img
                         className='indicator-reading__fish'
-                        src={getFishIcon(rating)}
+                        src={getFishIconForVariableRating(variableRating)}
                         alt=''
                     />
                     <div className='indicator-reading__reading'>
@@ -46,7 +50,7 @@ export default function SensorDetail({ sensor, sensorRatings, sensorData }) {
                     </div>
                     <img
                         className='indicator-reading__background'
-                        src={getFishBackground(rating)}
+                        src={getFishBackgroundForVariableRating(variableRating)}
                         alt=''
                     />
                 </div>

--- a/src/app/src/SensorMarker.js
+++ b/src/app/src/SensorMarker.js
@@ -13,7 +13,7 @@ export default function SensorMarker(props) {
 
     const handleOnClick = () => {
         if (!selectedSensor) {
-            selectSensor(sensor.properties.Location);
+            selectSensor(sensor);
             props.handleOnClick({
                 latitude: sensor.geometry.coordinates[1],
                 longitude: sensor.geometry.coordinates[0] + adj,

--- a/src/app/src/SensorMarker.js
+++ b/src/app/src/SensorMarker.js
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { selectSensor } from './app.actions';
-import positiveFishIcon from './img/fish_positive.svg';
+import { getFishIconForOverallRating, getClassNameFromOverallRating } from './sensorUtils';
 
 export default function SensorMarker(props) {
-    const { sensor, selectedSensor } = props;
+    const { sensor, selectedSensor, sensorOverallRating } = props;
 
     // Makes sure the marker is centered in the visible
     // portion of the map, since half of the map is
@@ -26,14 +26,14 @@ export default function SensorMarker(props) {
 
     return (
         <div onClick={handleOnClick}>
-            <div className='marker marker--positive'>
+            <div className={`marker marker--${getClassNameFromOverallRating(sensorOverallRating)}`}>
                 <div className='marker__inner'>
                     <div className='marker__content'>
                         <div className='marker__level' />
                         <div className='marker__symbol'>
                             <img
                                 className='marker__image'
-                                src={positiveFishIcon}
+                                src={getFishIconForOverallRating(sensorOverallRating)}
                                 alt='Sensor marker'
                             />
                         </div>

--- a/src/app/src/SensorMarker.js
+++ b/src/app/src/SensorMarker.js
@@ -1,7 +1,10 @@
 import React from 'react';
 
 import { selectSensor } from './app.actions';
-import { getFishIconForOverallRating, getClassNameFromOverallRating } from './sensorUtils';
+import {
+    getFishIconForOverallRating,
+    getClassNameFromOverallRating,
+} from './sensorUtils';
 
 export default function SensorMarker(props) {
     const { sensor, selectedSensor, sensorOverallRating } = props;
@@ -26,14 +29,20 @@ export default function SensorMarker(props) {
 
     return (
         <div onClick={handleOnClick}>
-            <div className={`marker marker--${getClassNameFromOverallRating(sensorOverallRating)}`}>
+            <div
+                className={`marker marker--${getClassNameFromOverallRating(
+                    sensorOverallRating
+                )}`}
+            >
                 <div className='marker__inner'>
                     <div className='marker__content'>
                         <div className='marker__level' />
                         <div className='marker__symbol'>
                             <img
                                 className='marker__image'
-                                src={getFishIconForOverallRating(sensorOverallRating)}
+                                src={getFishIconForOverallRating(
+                                    sensorOverallRating
+                                )}
                                 alt='Sensor marker'
                             />
                         </div>

--- a/src/app/src/SensorOverview.js
+++ b/src/app/src/SensorOverview.js
@@ -5,7 +5,12 @@ import SensorDetails from './SensorDetails';
 import { showSensorModal } from './app.actions';
 import { getClassNameFromOverallRating } from './sensorUtils';
 
-export default function SensorOverview({ sensor, sensorRatings, sensorData, isSensorModalDisplayed }) {
+export default function SensorOverview({
+    sensor,
+    sensorRatings,
+    sensorData,
+    isSensorModalDisplayed,
+}) {
     return (
         <div className='main l-detail l-detail--tinicum'>
             <div className='sidebar'>
@@ -20,9 +25,15 @@ export default function SensorOverview({ sensor, sensorRatings, sensorData, isSe
                         </p>
                     </header>
 
-                    <div className={`health health--${getClassNameFromOverallRating(sensorRatings.OVERALL_RATING)}`}>
+                    <div
+                        className={`health health--${getClassNameFromOverallRating(
+                            sensorRatings.OVERALL_RATING
+                        )}`}
+                    >
                         <h3 className='health__heading'>
-                            This site is in {sensorRatings.OVERALL_RATING.toLowerCase()} condition!
+                            This site is in{' '}
+                            {sensorRatings.OVERALL_RATING.toLowerCase()}{' '}
+                            condition!
                         </h3>
                         <div className='health__illustration'>
                             <button

--- a/src/app/src/SensorOverview.js
+++ b/src/app/src/SensorOverview.js
@@ -4,7 +4,7 @@ import listUl from './img/list-ul.svg';
 import SensorDetails from './SensorDetails';
 import { showSensorModal } from './app.actions';
 
-export default function SensorOverview({ sensor, isSensorModalDisplayed }) {
+export default function SensorOverview({ sensor, sensorRatings, sensorData, isSensorModalDisplayed }) {
     return (
         <div className='main l-detail l-detail--tinicum'>
             <div className='sidebar'>
@@ -21,7 +21,7 @@ export default function SensorOverview({ sensor, isSensorModalDisplayed }) {
 
                     <div className='health health--positive'>
                         <h3 className='health__heading'>
-                            This site is in healthy condition!
+                            This site is in {sensorRatings.OVERALL_RATING.toLowerCase()} condition!
                         </h3>
                         <div className='health__illustration'>
                             <button
@@ -37,7 +37,11 @@ export default function SensorOverview({ sensor, isSensorModalDisplayed }) {
                                 />
                             </button>
                             {isSensorModalDisplayed ? (
-                                <SensorDetails sensor={sensor} />
+                                <SensorDetails
+                                    sensor={sensor}
+                                    sensorData={sensorData}
+                                    sensorRatings={sensorRatings}
+                                />
                             ) : null}
                             <div className='health__level' />
                         </div>

--- a/src/app/src/SensorOverview.js
+++ b/src/app/src/SensorOverview.js
@@ -3,6 +3,7 @@ import React from 'react';
 import listUl from './img/list-ul.svg';
 import SensorDetails from './SensorDetails';
 import { showSensorModal } from './app.actions';
+import { getClassNameFromOverallRating } from './sensorUtils';
 
 export default function SensorOverview({ sensor, sensorRatings, sensorData, isSensorModalDisplayed }) {
     return (
@@ -19,7 +20,7 @@ export default function SensorOverview({ sensor, sensorRatings, sensorData, isSe
                         </p>
                     </header>
 
-                    <div className='health health--positive'>
+                    <div className={`health health--${getClassNameFromOverallRating(sensorRatings.OVERALL_RATING)}`}>
                         <h3 className='health__heading'>
                             This site is in {sensorRatings.OVERALL_RATING.toLowerCase()} condition!
                         </h3>

--- a/src/app/src/app.reducers.js
+++ b/src/app/src/app.reducers.js
@@ -1,6 +1,8 @@
 import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 
+import sensors from './sensors.json';
+
 import {
     hideIntro,
     selectSensor,
@@ -19,6 +21,7 @@ const initialAppState = {
     isSensorModalDisplayed: false,
     sensorData: DEFAULT_SENSOR_DATA,
     sensorRatings: {},
+    sensors: sensors
 };
 
 const appReducer = createReducer(

--- a/src/app/src/app.reducers.js
+++ b/src/app/src/app.reducers.js
@@ -21,7 +21,7 @@ const initialAppState = {
     isSensorModalDisplayed: false,
     sensorData: DEFAULT_SENSOR_DATA,
     sensorRatings: {},
-    sensors: sensors
+    sensors: sensors,
 };
 
 const appReducer = createReducer(

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -10,6 +10,33 @@ export const TURBIDITY = 'TURBIDITY';
 // Explicitly ordered to match the rigid ordering of the live sensor API response
 export const VARIABLES = [TEMPERATURE, OXYGEN, PH, TURBIDITY];
 
+export const VARIABLE_DETAILS = {
+    [TEMPERATURE]: {
+        name: 'Water Temperature',
+        description:
+            'Water temperature affects the growth and reproduction of living organisms as well as water density.',
+        unit: '°F',
+    },
+    [OXYGEN]: {
+        name: 'Dissolved Oxygen',
+        description:
+            'A measure of the concentration of oxygen dissolved in a body of water, relative to the maximum concentration.',
+        unit: 'mg/L',
+    },
+    [PH]: {
+        name: 'pH',
+        description:
+            'pH is a quantitative measure of the acidity (below 7.0pH) or basicity (above 7.0pH) in a body of water.',
+        unit: 'pH',
+    },
+    [TURBIDITY]: {
+        name: 'Turbidity',
+        description:
+            'Turbidity is a measurement of the cloudiness in a body of water. This cloudiness is caused by the presense of particles that can be invisible to the human eye.',
+        unit: 'NTU',
+    },
+};
+
 // Variables are rather named by USGS parameter code in the quarterly CSV data
 export const VARIABLE_CODES = {
     [TEMPERATURE]: '00010',

--- a/src/app/src/map.reducers.js
+++ b/src/app/src/map.reducers.js
@@ -1,7 +1,6 @@
 import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 
-import sensors from './sensors.json';
 import { toggleBackToMapButton, updateViewport } from './map.actions';
 
 // Map-related state
@@ -16,8 +15,7 @@ export const initialMapState = {
         pitch: 60,
         height: '100vh',
         width: '100vw',
-    },
-    sensors: sensors,
+    }
 };
 
 // Map-related reducer

--- a/src/app/src/map.reducers.js
+++ b/src/app/src/map.reducers.js
@@ -15,7 +15,7 @@ export const initialMapState = {
         pitch: 60,
         height: '100vh',
         width: '100vw',
-    }
+    },
 };
 
 // Map-related reducer

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -162,23 +162,22 @@ export function getClassNameFromVariableRating(rating) {
     return rating === 0 ? 'negative' : 'positive';
 }
 
-
 export function getFishIconForOverallRating(rating) {
     if (rating === RATING_GOOD) {
-        return positiveFishIcon
+        return positiveFishIcon;
     } else if (rating === RATING_POOR) {
-        return negativeFishIcon
+        return negativeFishIcon;
     } else {
-        return warningFishIcon
+        return warningFishIcon;
     }
 }
 
 export function getClassNameFromOverallRating(rating) {
     if (rating === RATING_GOOD) {
-        return 'positive'
+        return 'positive';
     } else if (rating === RATING_POOR) {
-        return 'negative'
+        return 'negative';
     } else {
-        return 'warning'
+        return 'warning';
     }
 }

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -13,9 +13,15 @@ import {
     RATING_FAIR,
     RATING_POOR,
     LAST_LIVE_SENSOR_DATE,
-    LAST_QUARTERLY_SURVEY_DATE
+    LAST_QUARTERLY_SURVEY_DATE,
 } from './constants';
 import sensors from './sensors.json';
+import positiveFishIcon from './img/fish_positive.svg';
+import positiveBackground from './img/health_background_positive.svg';
+import warningFishIcon from './img/fish_warning.svg';
+import warningBackground from './img/health_background_warning.svg';
+import negativeFishIcon from './img/fish_negative.svg';
+import negativeBackground from './img/health_background_negative.svg';
 
 export function makeRiverGaugeRequest(id, isApiRequest) {
     const commaSeparatedCodes = Object.keys(VARIABLE_CODES).reduce(
@@ -44,21 +50,28 @@ export function parseCsvString(csvString) {
 
 export function parseRiverGaugeApiData(id, data) {
     // API data sends variable data in the same order mirrored in VARIABLES
-    const extractedVariableData = VARIABLES.reduce((acc, variable, idx) => {
-        const apiVariableData = data[idx];
-        if (apiVariableData) {
-            // Step backwards in time until we find actual live sensor readings
-            const descendingTimeApiVariableData = Array.from(apiVariableData.values[0].value).reverse();
-            const sensorReading = descendingTimeApiVariableData.find(
-                sensorReading => Number(sensorReading.value) !== apiVariableData.variable.noDataValue
-            );
-            return Object.assign(acc, {
-                [variable]: Number(sensorReading.value),
-                timestamp: new Date(sensorReading.dateTime)
-            });
-        }
-        return acc;
-    }, { id });
+    const extractedVariableData = VARIABLES.reduce(
+        (acc, variable, idx) => {
+            const apiVariableData = data[idx];
+            if (apiVariableData) {
+                // Step backwards in time until we find actual live sensor readings
+                const descendingTimeApiVariableData = Array.from(
+                    apiVariableData.values[0].value
+                ).reverse();
+                const sensorReading = descendingTimeApiVariableData.find(
+                    sensorReading =>
+                        Number(sensorReading.value) !==
+                        apiVariableData.variable.noDataValue
+                );
+                return Object.assign(acc, {
+                    [variable]: Number(sensorReading.value),
+                    timestamp: new Date(sensorReading.dateTime),
+                });
+            }
+            return acc;
+        },
+        { id }
+    );
 
     return extractedVariableData;
 }
@@ -68,12 +81,17 @@ export function parseRiverGaugeCsvData(id, data) {
         return false;
     }
     const dataRow = data.slice(-1)[0];
-    const timestamp = new Date(`${dataRow.sample_dt} ${dataRow.sample_start_time_datum_cd}`);
+    const timestamp = new Date(
+        `${dataRow.sample_dt} ${dataRow.sample_start_time_datum_cd}`
+    );
 
-    const extractedVariableData = VARIABLES.reduce((acc, variable) => {
-        const code = `p${VARIABLE_CODES[variable]}`;
-        return Object.assign(acc, { [variable]: dataRow[code] || 0 });
-    }, { id, timestamp });
+    const extractedVariableData = VARIABLES.reduce(
+        (acc, variable) => {
+            const code = `p${VARIABLE_CODES[variable]}`;
+            return Object.assign(acc, { [variable]: dataRow[code] || 0 });
+        },
+        { id, timestamp }
+    );
 
     return extractedVariableData;
 }
@@ -115,4 +133,28 @@ export function transformSensorDataToRatings(sensorData) {
             [OVERALL_RATING]: calculateOverallSensorRating(sensorRatings),
         },
     };
+}
+
+export function getFishIcon(rating) {
+    if (rating === VARIABLE_WITHIN_HEALTHY_RANGE) {
+        return positiveFishIcon;
+    } else if (rating === VARIABLE_NOT_WITHIN_HEALTHY_RANGE) {
+        return negativeFishIcon;
+    } else {
+        return warningFishIcon;
+    }
+}
+
+export function getFishBackground(rating) {
+    if (rating === VARIABLE_WITHIN_HEALTHY_RANGE) {
+        return positiveBackground;
+    } else if (rating === VARIABLE_NOT_WITHIN_HEALTHY_RANGE) {
+        return negativeBackground;
+    } else {
+        return warningBackground;
+    }
+}
+
+export function getRatingClassName(rating) {
+    return rating === 0 ? 'negative' : 'positive';
 }

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -135,7 +135,8 @@ export function transformSensorDataToRatings(sensorData) {
     };
 }
 
-export function getFishIcon(rating) {
+export function getFishIconForVariableRating(rating) {
+    // TODO #69: Figure out how the warning state is defined
     if (rating === VARIABLE_WITHIN_HEALTHY_RANGE) {
         return positiveFishIcon;
     } else if (rating === VARIABLE_NOT_WITHIN_HEALTHY_RANGE) {
@@ -145,7 +146,8 @@ export function getFishIcon(rating) {
     }
 }
 
-export function getFishBackground(rating) {
+export function getFishBackgroundForVariableRating(rating) {
+    // TODO #69: Figure out how the warning state is defined
     if (rating === VARIABLE_WITHIN_HEALTHY_RANGE) {
         return positiveBackground;
     } else if (rating === VARIABLE_NOT_WITHIN_HEALTHY_RANGE) {
@@ -155,6 +157,28 @@ export function getFishBackground(rating) {
     }
 }
 
-export function getRatingClassName(rating) {
+export function getClassNameFromVariableRating(rating) {
+    // TODO #69: Figure out how the warning state is defined
     return rating === 0 ? 'negative' : 'positive';
+}
+
+
+export function getFishIconForOverallRating(rating) {
+    if (rating === RATING_GOOD) {
+        return positiveFishIcon
+    } else if (rating === RATING_POOR) {
+        return negativeFishIcon
+    } else {
+        return warningFishIcon
+    }
+}
+
+export function getClassNameFromOverallRating(rating) {
+    if (rating === RATING_GOOD) {
+        return 'positive'
+    } else if (rating === RATING_POOR) {
+        return 'negative'
+    } else {
+        return 'warning'
+    }
 }


### PR DESCRIPTION
## Overview

This sprint, we set up all the data needed for the front-end. This PR subs in dynamically generated data to the frontend, which previously showed static dummy data.

Connects #41
Connects #43 

(I accidentally did both)

### Demo

<img width="699" alt="screen shot 2019-03-04 at 1 00 19 pm" src="https://user-images.githubusercontent.com/10568752/53755434-8e914100-3e84-11e9-910f-e13101e0049c.png">
<img width="706" alt="screen shot 2019-03-04 at 1 00 28 pm" src="https://user-images.githubusercontent.com/10568752/53755435-8e914100-3e84-11e9-894a-aa2ffb1292f3.png">
<img width="455" alt="screen shot 2019-03-04 at 12 32 27 pm" src="https://user-images.githubusercontent.com/10568752/53755436-8e914100-3e84-11e9-8a6e-de1163db2c01.png">
<img width="455" alt="screen shot 2019-03-04 at 12 32 37 pm" src="https://user-images.githubusercontent.com/10568752/53755437-8e914100-3e84-11e9-9ad4-041cb5487f86.png">


### Notes

You will see some TODOs. We will need some guidance from the client about how the variable score translates to qualitative buckets (positive, warning, and negative) given its range (i.e. 1-50NTU for Turbidity). For now, it was decided to just categorize scores as positive and negative if they are in or outside the range, respectively.

I was tempted to roll in #64, but am anticipating a fair amount of conflict rebasing on #63 already so I forewent that.

## Testing Instructions

Netlify will suffice.