### PR TITLE
Display dynamic timestamp in footer

### DIFF
--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -47,18 +47,13 @@ class App extends Component {
             const sensorId = sensor.properties.Id;
             return sensorData[sensorId].timestamp;
         });
-        const mostRecentDate = Math.max(...sensorReadingDates);
-        const msElapsedSinceLastUpdate =
-            mostRecentDate === 0 ? null : new Date().getTime() - mostRecentDate;
 
         return (
             <div id='app-container' className={containerClassName}>
                 {isIntroVisible ? <Intro /> : null}
                 <div className='main l-landing'>
                     <Header />
-                    <Footer
-                        msElapsedSinceLastUpdate={msElapsedSinceLastUpdate}
-                    />
+                    <Footer sensorReadingDates={sensorReadingDates} />
                 </div>
                 <GLMap />
                 {selectedSensor !== null ? (

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -7,7 +7,7 @@ import Header from './Header';
 import Footer from './Footer';
 import SensorOverview from './SensorOverview';
 
-import { POLLING_INTERVAL } from './constants';
+import { POLLING_INTERVAL, msPerDay, msPerHour } from './constants';
 import { pollSensor } from './app.actions';
 import { msToDays, msToHours, msToMins } from './sensorUtils';
 
@@ -55,10 +55,10 @@ class App extends Component {
         // Minutes if < 1 hr; hours if 1h - 24h; days if 1 day+
         let timeSinceLastUpdate = msToMins(msElapsedSinceLastUpdate);
         let timeLabel = 'minutes';
-        if (timeSinceLastUpdate >= 1440) {
+        if (timeSinceLastUpdate >= msPerDay) {
             timeSinceLastUpdate = msToDays(msElapsedSinceLastUpdate);
             timeLabel = 'days';
-        } else if (timeSinceLastUpdate >= 60) {
+        } else if (timeSinceLastUpdate >= msPerHour) {
             timeSinceLastUpdate = msToHours(msElapsedSinceLastUpdate);
             timeLabel = 'hours';
         }

--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -7,15 +7,13 @@ import Header from './Header';
 import Footer from './Footer';
 import SensorOverview from './SensorOverview';
 
-import { POLLING_INTERVAL, msPerDay, msPerHour } from './constants';
+import { POLLING_INTERVAL } from './constants';
 import { pollSensor } from './app.actions';
-import { msToDays, msToHours, msToMins } from './sensorUtils';
 
 class App extends Component {
     componentDidMount() {
         // Poll for new sensor data immediately and on a timed cycle thereafter
         const { dispatch, sensors } = this.props;
-
         const fetchSensorData = sensor => dispatch(pollSensor(sensor));
         this.pollSensorIntervalIds = sensors.features.map(sensor => {
             fetchSensorData(sensor);
@@ -49,19 +47,9 @@ class App extends Component {
             const sensorId = sensor.properties.Id;
             return sensorData[sensorId].timestamp;
         });
+        const mostRecentDate = Math.max(...sensorReadingDates);
         const msElapsedSinceLastUpdate =
-            new Date().getTime() - Math.max(...sensorReadingDates);
-        // Display footer timestamp in sensible units
-        // Minutes if < 1 hr; hours if 1h - 24h; days if 1 day+
-        let timeSinceLastUpdate = msToMins(msElapsedSinceLastUpdate);
-        let timeLabel = 'minutes';
-        if (timeSinceLastUpdate >= msPerDay) {
-            timeSinceLastUpdate = msToDays(msElapsedSinceLastUpdate);
-            timeLabel = 'days';
-        } else if (timeSinceLastUpdate >= msPerHour) {
-            timeSinceLastUpdate = msToHours(msElapsedSinceLastUpdate);
-            timeLabel = 'hours';
-        }
+            mostRecentDate === 0 ? null : new Date().getTime() - mostRecentDate;
 
         return (
             <div id='app-container' className={containerClassName}>
@@ -69,8 +57,7 @@ class App extends Component {
                 <div className='main l-landing'>
                     <Header />
                     <Footer
-                        elapsedTime={timeSinceLastUpdate}
-                        timeLabel={timeLabel}
+                        msElapsedSinceLastUpdate={msElapsedSinceLastUpdate}
                     />
                 </div>
                 <GLMap />

--- a/src/app/src/Footer.js
+++ b/src/app/src/Footer.js
@@ -1,26 +1,22 @@
-import React, { Component } from 'react';
+import React from 'react';
 
 import feedIcon from './img/feed.svg';
 
-class Footer extends Component {
-    render() {
-        return (
-            <footer className='footer footer--current-reading'>
-                <div className='footer__content'>
-                    <div className='footer__icon'>
-                        <img
-                            className='footer__image'
-                            src={feedIcon}
-                            alt='Feed icon'
-                        />
-                    </div>
-                    <p className='footer__text'>
-                        Health reading last updated 3 minutes ago!
-                    </p>
+export default function Footer({ elapsedTime, timeLabel }) {
+    return (
+        <footer className='footer footer--current-reading'>
+            <div className='footer__content'>
+                <div className='footer__icon'>
+                    <img
+                        className='footer__image'
+                        src={feedIcon}
+                        alt='Feed icon'
+                    />
                 </div>
-            </footer>
-        );
-    }
+                <p className='footer__text'>
+                    Health reading last updated {elapsedTime} {timeLabel} ago!
+                </p>
+            </div>
+        </footer>
+    );
 }
-
-export default Footer;

--- a/src/app/src/Footer.js
+++ b/src/app/src/Footer.js
@@ -1,8 +1,14 @@
 import React from 'react';
 
 import feedIcon from './img/feed.svg';
+import { getElapsedTimeLabel } from './sensorUtils';
 
-export default function Footer({ elapsedTime, timeLabel }) {
+export default function Footer({ msElapsedSinceLastUpdate }) {
+    const label = getElapsedTimeLabel(msElapsedSinceLastUpdate);
+    const message = label
+        ? `Health reading last updated ${label}.`
+        : 'Common sensor readings displayed for each site.';
+
     return (
         <footer className='footer footer--current-reading'>
             <div className='footer__content'>
@@ -13,9 +19,8 @@ export default function Footer({ elapsedTime, timeLabel }) {
                         alt='Feed icon'
                     />
                 </div>
-                <p className='footer__text'>
-                    Health reading last updated {elapsedTime} {timeLabel} ago!
-                </p>
+                <p className='footer__text' />
+                {message}
             </div>
         </footer>
     );

--- a/src/app/src/Footer.js
+++ b/src/app/src/Footer.js
@@ -1,9 +1,16 @@
 import React from 'react';
 
 import feedIcon from './img/feed.svg';
-import { getElapsedTimeLabel } from './sensorUtils';
+import {
+    getElapsedTimeLabel,
+    getMostRecentDateFromList,
+    getElapsedTimeSince,
+} from './sensorUtils';
 
-export default function Footer({ msElapsedSinceLastUpdate }) {
+export default function Footer({ sensorReadingDates }) {
+    const msElapsedSinceLastUpdate = getElapsedTimeSince(
+        getMostRecentDateFromList(sensorReadingDates)
+    );
     const label = getElapsedTimeLabel(msElapsedSinceLastUpdate);
     const message = label
         ? `Health reading last updated ${label}.`

--- a/src/app/src/__tests__/sensorutils.tests.js
+++ b/src/app/src/__tests__/sensorutils.tests.js
@@ -6,6 +6,7 @@ import {
     transformSensorDataToRatings,
     calculateOverallSensorRating,
     getElapsedTimeLabel,
+    getMostRecentDateFromList,
 } from '../sensorUtils';
 
 import {
@@ -144,6 +145,17 @@ it('transforms sensor data to sensor ratings', () => {
     );
 
     expect(actualSensorRatings.sensorRatings).toEqual(expectedSensorRatings);
+});
+
+it('selects the most recent date', () => {
+    const december = new Date('2018-12-01');
+    const november = new Date('2018-11-01');
+    const may = new Date('2018-05-10');
+
+    const dates = [may, november, december];
+    const decemberAsNum = december.getTime();
+
+    expect(getMostRecentDateFromList(dates)).toEqual(decemberAsNum);
 });
 
 it('transforms sensor data timestamps to the expected message', () => {

--- a/src/app/src/__tests__/sensorutils.tests.js
+++ b/src/app/src/__tests__/sensorutils.tests.js
@@ -5,6 +5,7 @@ import {
     parseRiverGaugeCsvData,
     transformSensorDataToRatings,
     calculateOverallSensorRating,
+    getElapsedTimeLabel,
 } from '../sensorUtils';
 
 import {
@@ -13,9 +14,14 @@ import {
     RATING_GOOD,
     RATING_FAIR,
     RATING_POOR,
+    msPerHour,
+    msPerYear,
+    msPerDay,
+    msPerMinute,
 } from '../constants';
 
 it('parses real-time sensor data', () => {
+    const date = '2018-12-04T14:30:00.000-05:00';
     const createTestSensorReading = () => {
         return {
             values: [
@@ -23,6 +29,7 @@ it('parses real-time sensor data', () => {
                     value: [
                         {
                             value: 1,
+                            dateTime: date,
                         },
                     ],
                 },
@@ -41,6 +48,7 @@ it('parses real-time sensor data', () => {
         OXYGEN: 1,
         PH: 1,
         TURBIDITY: 1,
+        timestamp: new Date(date),
     };
 
     const actualParsedSensorData = parseRiverGaugeApiData('0', testSensorData);
@@ -49,6 +57,9 @@ it('parses real-time sensor data', () => {
 });
 
 it('parses quarterly sensor data', () => {
+    const date = '2018-12-04';
+    const timezone = 'EST';
+
     const testSensorData = [
         {},
         {
@@ -56,8 +67,8 @@ it('parses quarterly sensor data', () => {
             p00300: 12.4,
             p00400: 7.3,
             p63680: 3.3,
-            sample_dt: '2018-12-04',
-            sample_start_time_datum_cd: 'EST',
+            sample_dt: date,
+            sample_start_time_datum_cd: timezone,
             sample_tm: '12:00',
             site_no: 1438500,
         },
@@ -71,6 +82,7 @@ it('parses quarterly sensor data', () => {
         OXYGEN: 12.4,
         PH: 7.3,
         TURBIDITY: 3.3,
+        timestamp: new Date(`${date} ${timezone}`),
     };
 
     expect(actualParsedSensorData).toEqual(expectedParsedSensorData);
@@ -116,6 +128,7 @@ it('transforms sensor data to sensor ratings', () => {
         OXYGEN: 12.4,
         PH: 7.3,
         TURBIDITY: 3.3,
+        timestamp: new Date(),
     };
 
     const expectedSensorRatings = {
@@ -131,4 +144,25 @@ it('transforms sensor data to sensor ratings', () => {
     );
 
     expect(actualSensorRatings.sensorRatings).toEqual(expectedSensorRatings);
+});
+
+it('transforms sensor data timestamps to the expected message', () => {
+    // time in milliseconds (ms)
+    const overOneYearAgo = msPerYear + 1;
+    const oneYearAgo = msPerYear;
+    const oneDayAgo = msPerDay;
+    const twoDaysAgo = msPerDay * 2;
+    const tenDaysAgo = msPerDay * 10;
+    const tenHoursAgo = msPerHour * 10;
+    const minutesAgo = msPerMinute * 59;
+
+    expect(getElapsedTimeLabel(overOneYearAgo)).toEqual('over a year ago');
+    expect(getElapsedTimeLabel(oneYearAgo)).toEqual('in the past year');
+    expect(getElapsedTimeLabel(tenDaysAgo)).toEqual('in the past month');
+    expect(getElapsedTimeLabel(twoDaysAgo)).toEqual('in the past week');
+    expect(getElapsedTimeLabel(oneDayAgo)).toEqual('yesterday');
+    expect(getElapsedTimeLabel(tenHoursAgo)).toEqual('10 hours ago');
+    expect(getElapsedTimeLabel(minutesAgo)).toEqual('59 minutes ago');
+    expect(getElapsedTimeLabel(0)).toEqual('0 minutes ago');
+    expect(getElapsedTimeLabel(null)).toEqual(false);
 });

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -65,3 +65,6 @@ export const DEFAULT_SENSOR_DATA = SENSORS.features.reduce(
         }),
     {}
 );
+
+export const msPerDay = 1440;
+export const msPerHour = 60;

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -66,7 +66,9 @@ export const DEFAULT_SENSOR_DATA = SENSORS.features.reduce(
     {}
 );
 
-export const msPerHour = 6000000;
+const msPerSecond = 1000;
+export const msPerMinute = msPerSecond * 60;
+export const msPerHour = msPerMinute * 60;
 export const msPerDay = msPerHour * 24;
 export const msPerWeek = msPerDay * 7;
 export const msPerMonth = msPerDay * 30; // roughly a month, 30 days

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -66,5 +66,8 @@ export const DEFAULT_SENSOR_DATA = SENSORS.features.reduce(
     {}
 );
 
-export const msPerDay = 1440;
-export const msPerHour = 60;
+export const msPerHour = 6000000;
+export const msPerDay = msPerHour * 24;
+export const msPerWeek = msPerDay * 7;
+export const msPerMonth = msPerDay * 30; // roughly a month, 30 days
+export const msPerYear = msPerWeek * 52;

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -226,3 +226,11 @@ export function getElapsedTimeLabel(elapsedTimeInMS) {
         return false;
     }
 }
+
+export function getMostRecentDateFromList(dates) {
+    return Math.max(...dates);
+}
+
+export function getElapsedTimeSince(date) {
+    return date === 0 ? null : new Date().getTime() - date;
+}

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -14,6 +14,10 @@ import {
     RATING_POOR,
     LAST_LIVE_SENSOR_DATE,
     LAST_QUARTERLY_SURVEY_DATE,
+    msPerHour,
+    msPerMonth,
+    msPerWeek,
+    msPerYear,
 } from './constants';
 import sensors from './sensors.json';
 import positiveFishIcon from './img/fish_positive.svg';
@@ -182,14 +186,45 @@ export function getClassNameFromOverallRating(rating) {
     }
 }
 
-export function msToDays(ms) {
-    return Math.round(ms / (1000 * 60 * 60 * 24));
-}
-
 export function msToHours(ms) {
     return Math.round(ms / (1000 * 60 * 60));
 }
 
 export function msToMins(ms) {
     return Math.round(ms / (1000 * 60));
+}
+
+export function getElapsedTimeLabel(elapsedTimeInMS) {
+    // Live sensors data can become stale
+    // Return a sensible message around elapsed time since last data update
+
+    if (!elapsedTimeInMS) {
+        return false;
+    }
+
+    const now = new Date();
+    const midnightYesterday = new Date(
+        new Date().setDate(now.getDate() - 1)
+    ).setHours(0, 0, 0, 0);
+    const midnightTwoDaysAgo = new Date(
+        new Date().setDate(now.getDate() - 2)
+    ).setHours(0, 0, 0, 0);
+
+    if (elapsedTimeInMS > msPerYear) {
+        return 'over a year ago';
+    } else if (elapsedTimeInMS > msPerMonth) {
+        return 'in the past year';
+    } else if (elapsedTimeInMS > msPerWeek) {
+        return 'in the past month';
+    } else if (elapsedTimeInMS > now - midnightTwoDaysAgo) {
+        return 'in the past week';
+    } else if (elapsedTimeInMS > now - midnightYesterday) {
+        return 'yesterday';
+    } else if (elapsedTimeInMS > msPerHour) {
+        return `${msToHours(elapsedTimeInMS)} hours ago`;
+    } else if (elapsedTimeInMS >= 0) {
+        return `${msToMins(elapsedTimeInMS)} minutes ago`;
+    } else {
+        return false;
+    }
 }

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -198,16 +198,14 @@ export function getElapsedTimeLabel(elapsedTimeInMS) {
     // Live sensors data can become stale
     // Return a sensible message around elapsed time since last data update
 
-    if (!elapsedTimeInMS) {
+    if (elapsedTimeInMS === null) {
         return false;
     }
 
     const now = new Date();
+    const midnightToday = new Date(new Date().setHours(0, 0, 0, 0));
     const midnightYesterday = new Date(
         new Date().setDate(now.getDate() - 1)
-    ).setHours(0, 0, 0, 0);
-    const midnightTwoDaysAgo = new Date(
-        new Date().setDate(now.getDate() - 2)
     ).setHours(0, 0, 0, 0);
 
     if (elapsedTimeInMS > msPerYear) {
@@ -216,9 +214,9 @@ export function getElapsedTimeLabel(elapsedTimeInMS) {
         return 'in the past year';
     } else if (elapsedTimeInMS > msPerWeek) {
         return 'in the past month';
-    } else if (elapsedTimeInMS > now - midnightTwoDaysAgo) {
-        return 'in the past week';
     } else if (elapsedTimeInMS > now - midnightYesterday) {
+        return 'in the past week';
+    } else if (elapsedTimeInMS > now - midnightToday) {
         return 'yesterday';
     } else if (elapsedTimeInMS > msPerHour) {
         return `${msToHours(elapsedTimeInMS)} hours ago`;

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -181,3 +181,15 @@ export function getClassNameFromOverallRating(rating) {
         return 'warning';
     }
 }
+
+export function msToDays(ms) {
+    return Math.round(ms / (1000 * 60 * 60 * 24));
+}
+
+export function msToHours(ms) {
+    return Math.round(ms / (1000 * 60 * 60));
+}
+
+export function msToMins(ms) {
+    return Math.round(ms / (1000 * 60));
+}


### PR DESCRIPTION
## Overview

The footer now displays a real value for time since last and latest data update. ~Time is displayed as days, hours, or minutes based on what seems sensible. I didn't consider the next jump up which is months, but I can add that 🤔Since sensors haven't been updating real-time as hoped for the app despite data being polled every 10 minutes, the timestamp is as of now kind of a let down 😢 ~
Edit: Display a time indicator that is appropriate for the time elapsed. The longer the time frame, the softer the messaging.

Connects #42

### Demo

Using default data:
![screen shot 2019-03-05 at 5 24 35 pm](https://user-images.githubusercontent.com/10568752/53841898-fff7ef00-3f6b-11e9-806e-8de3b03d288d.png)

Using live sensor data:
![screen shot 2019-03-05 at 5 25 02 pm](https://user-images.githubusercontent.com/10568752/53841899-fff7ef00-3f6b-11e9-91c4-3d0fa9c7e9da.png)

### Notes

~I was ambivalent between putting the logic in `App.js` vs `Footer.jsx`. I don't think it matters too much, however if you have a strong argument to move the logic to the Footer, I will consider.~ Moved to utils, makes sense in retrospect.

## Testing Instructions

Netlify should suffice.