### PR TITLE
Adjust positioning of bottom map elements

### DIFF
--- a/src/app/src/Footer.js
+++ b/src/app/src/Footer.js
@@ -26,8 +26,7 @@ export default function Footer({ sensorReadingDates }) {
                         alt='Feed icon'
                     />
                 </div>
-                <p className='footer__text' />
-                {message}
+                <p className='footer__text'>{message}</p>
             </div>
         </footer>
     );

--- a/src/app/src/SensorOverview.js
+++ b/src/app/src/SensorOverview.js
@@ -21,7 +21,7 @@ export default function SensorOverview({
                             {sensor.properties.Location}
                         </h2>
                         <p className='sidebar__intro'>
-                            {sensor.properties.Name}
+                            {sensor.properties.Description}
                         </p>
                     </header>
 

--- a/src/app/src/img/compass.svg
+++ b/src/app/src/img/compass.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="51px" height="51px" viewBox="0 0 51 51" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>Compass</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Designs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Home" transform="translate(-1280.000000, -894.000000)" fill-rule="nonzero">
+            <g id="Compass" transform="translate(1273.000000, 887.000000)">
+                <circle id="Oval" fill="#14352D" cx="32.5" cy="32.5" r="24.5"></circle>
+                <path d="M32.5,58 C18.4167389,58 7,46.5832611 7,32.5 C7,18.4167389 18.4167389,7 32.5,7 C46.5832611,7 58,18.4167389 58,32.5 C58,46.5832611 46.5832611,58 32.5,58 Z M32.5,56 C45.4786916,56 56,45.4786916 56,32.5 C56,19.5213084 45.4786916,9 32.5,9 C19.5213084,9 9,19.5213084 9,32.5 C9,45.4786916 19.5213084,56 32.5,56 Z" id="Oval" fill="#D2ECEE"></path>
+                <g id="Group-5" transform="translate(32.853553, 33.353553) rotate(-315.000000) translate(-32.853553, -33.353553) translate(9.853553, 10.353553)">
+                    <g id="compass" transform="translate(0.221825, 0.000000)" fill="#D2ECEE">
+                        <polygon id="Triangle" transform="translate(14.500000, 15.221825) rotate(-45.000000) translate(-14.500000, -15.221825) " points="14.5 4.22182541 22 26.2218254 7 26.2218254"></polygon>
+                        <path d="M28.7216619,23 L22.2781746,4.09910381 L15.8346873,23 L22.2781746,41.9008962 L28.7216619,23 Z M30.7246848,23.3226739 L23.2246848,45.3226739 C22.9168093,46.2257754 21.6395399,46.2257754 21.3316644,45.3226739 L13.8316644,23.3226739 C13.7603447,23.1134693 13.7603447,22.8865307 13.8316644,22.6773261 L21.3316644,0.677326072 C21.6395399,-0.225775357 22.9168093,-0.225775357 23.2246848,0.677326072 L30.7246848,22.6773261 C30.7960045,22.8865307 30.7960045,23.1134693 30.7246848,23.3226739 Z" id="Combined-Shape" transform="translate(22.278175, 23.000000) rotate(-45.000000) translate(-22.278175, -23.000000) "></path>
+                    </g>
+                    <circle id="Oval" fill="#D8EFF1" cx="22.5" cy="23.5" r="2.5"></circle>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/app/src/sass/06_components/_button-back.scss
+++ b/src/app/src/sass/06_components/_button-back.scss
@@ -3,8 +3,8 @@
 
     position: absolute;
     cursor: pointer;
-    bottom: 3rem;
-    left: $pad-comfortable;
+    bottom: 2rem;
+    left: 4rem;
     letter-spacing: 1px;
     text-transform: uppercase;
     background: 0;

--- a/src/app/src/sass/06_components/_map.scss
+++ b/src/app/src/sass/06_components/_map.scss
@@ -13,26 +13,34 @@
 
 .mapboxgl-ctrl-compass {
   position: absolute;
-  bottom: 20px;
-  right: 40px;
   border-radius: 20px;
   border: 1px solid #D3ECEE !important;
 }
 
 .p-landing {
   .mapboxgl-ctrl-bottom-left {
-    bottom: 78px;
+    bottom: 45px;
   }
 
   .mapboxgl-ctrl-bottom-right {
-    bottom: 78px;
+    bottom: 45px;
+  }
+
+  .mapboxgl-ctrl-compass {
+    bottom: 55px;
+    right: 50px;
   }
 }
 
 .p-detail {
   .mapboxgl-ctrl-bottom-right {
+    left: 47%;
     right: inherit;
-    left: 160px;
-    bottom: 30px;
+  }
+
+  .mapboxgl-ctrl-compass {
+    bottom: 10px;
+    left: 43%;
+    right: inherit;
   }
 }

--- a/src/app/src/sass/06_components/_map.scss
+++ b/src/app/src/sass/06_components/_map.scss
@@ -13,34 +13,52 @@
 
 .mapboxgl-ctrl-compass {
   position: absolute;
-  border-radius: 20px;
-  border: 1px solid #D3ECEE !important;
+}
+
+.mapboxgl-ctrl-icon.mapboxgl-ctrl-compass > .mapboxgl-ctrl-compass-arrow {
+  width: 30px!important;
+  height: 30px!important;
+  background-image: url('../img/compass.svg')!important;
+  background-size: 25px;
+  background-position: center;
+  margin: 0!important;
 }
 
 .p-landing {
   .mapboxgl-ctrl-bottom-left {
-    bottom: 45px;
+    bottom: 50px;
+
+    // Our wrapper library doesn't support moving this in in the Mapbox API
+    right: 20px;
+    left: auto;
   }
 
   .mapboxgl-ctrl-bottom-right {
     bottom: 45px;
+    right: 11rem;
   }
 
   .mapboxgl-ctrl-compass {
-    bottom: 55px;
-    right: 50px;
+    top: 15px;
+    right: 20px;
   }
 }
 
 .p-detail {
+  .mapboxgl-ctrl-bottom-left {
+    bottom: 5px;
+
+    // Our wrapper library doesn't support moving this in in the Mapbox API
+    right: 66rem;
+    left: auto;
+  }
+
   .mapboxgl-ctrl-bottom-right {
-    left: 47%;
-    right: inherit;
+    right: 75rem;
   }
 
   .mapboxgl-ctrl-compass {
-    bottom: 10px;
-    left: 43%;
-    right: inherit;
+    top: 10px;
+    right: 66rem;
   }
 }

--- a/src/app/src/sass/06_components/_map.scss
+++ b/src/app/src/sass/06_components/_map.scss
@@ -49,16 +49,17 @@
     bottom: 5px;
 
     // Our wrapper library doesn't support moving this in in the Mapbox API
-    right: 66rem;
-    left: auto;
+    right: inherit;
+    left: 40%;
   }
 
   .mapboxgl-ctrl-bottom-right {
-    right: 75rem;
+    left: 38%;
+    right: inherit;
   }
 
   .mapboxgl-ctrl-compass {
     top: 10px;
-    right: 66rem;
+    left: 46%;
   }
 }

--- a/src/app/src/sensors.json
+++ b/src/app/src/sensors.json
@@ -6,6 +6,7 @@
       "properties": {
         "Location": "Tinicum",
         "Name": "USGS 01475548 Cobbs Creek at Mt. Moriah Cemetery, Philadelphia",
+        "Description": "The Tinicum site is near the Philadelphia International Airport at the southern-most end of the Delaware River Basin.",
         "Id": "01475548",
         "ApiAccess": true,
         "HealthyRanges": {
@@ -52,6 +53,7 @@
       "properties": {
         "Location": "Wissahickon",
         "Name": "USGS 01474000 Wissahickon Creek at Mouth, Philadelphia, PA",
+        "Description": "Wissahickon Creek runs through Fort Washington State Park before emptying into the Schuylkill River in Philadelphia.",
         "Id": "01474000",
         "ApiAccess": true,
         "HealthyRanges": {
@@ -98,6 +100,7 @@
       "properties": {
         "Location": "Delaware Water Gap",
         "Name": "USGS 01438500 Delaware River at Montague NJ",
+        "Description": "The Delaware Water Gap is where the Delaware River cuts through the Appalachian Mountains.",
         "Id": "01438500",
         "ApiAccess": false,
         "HealthyRanges": {


### PR DESCRIPTION
## Overview

Following up #55, now that the map height is consistent across devices, the position of the map controls along the bottom of the map are adjusted. The controls are positioned so that they are above the footer on the overview map and along the bottom of the map when the sensor pane is open.

The sensor description text is also added here as it was a relatively simple, largely cosmetic change.

Connects #75 
Connects #83 

### Demo

*Overview map*

![image](https://user-images.githubusercontent.com/1042475/54136861-ed116e80-43f2-11e9-8d7c-3ff6f3e6e1af.png)

*Map with sensor pane open*

![image](https://user-images.githubusercontent.com/1042475/54136886-f7cc0380-43f2-11e9-8413-4576430436e6.png)

## Testing Instructions

- View the site in both a desktop browser and on an iPad, and verify the bottom map controls are also visible. 