### PR TITLE
Reformat CSV timestamp to officially supported format

### DIFF
--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -86,7 +86,9 @@ export function parseRiverGaugeCsvData(id, data) {
     }
     const dataRow = data.slice(-1)[0];
     const timestamp = new Date(
-        `${dataRow.sample_dt} ${dataRow.sample_start_time_datum_cd}`
+        `${dataRow.sample_dt.replace(/-/g, '/')} ${
+            dataRow.sample_start_time_datum_cd
+        }`
     );
 
     const extractedVariableData = VARIABLES.reduce(


### PR DESCRIPTION
## Overview

The provided format can be parsed in Chrome, but not Safari, which is the target device for the app.

The solution is from https://stackoverflow.com/a/5646753

Connects #84

## Testing Instructions

- Visit the Delaware River sensor in both Chrome and Safari, and verify that the app works in both cases.