### PR TITLE
Implement intro screen transition

### DIFF
--- a/src/app/src/BackToMapButton.js
+++ b/src/app/src/BackToMapButton.js
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import { deselectSensor } from './app.actions';
-import { initialMapState } from './map.reducers';
+import { mapOverviewViewport } from './constants';
 import deRiverBasin from './img/de_river_basin.svg';
 
 export default function BackToMapButton(props) {
     const handleOnClick = () => {
         deselectSensor();
-        props.handleOnClick(initialMapState.viewport);
+        props.handleOnClick(mapOverviewViewport);
     };
 
     return (

--- a/src/app/src/Intro.js
+++ b/src/app/src/Intro.js
@@ -1,9 +1,17 @@
 import React, { Component } from 'react';
 
 import { hideIntro } from './app.actions';
+import { showMarkers, updateViewport } from './map.actions';
+import { mapOverviewViewport } from './constants';
 
 class Intro extends Component {
     render() {
+        const onClick = () => {
+            hideIntro();
+            showMarkers();
+            updateViewport(mapOverviewViewport);
+        };
+
         return (
             <div className='main l-intro'>
                 <main className='main__content'>
@@ -18,7 +26,7 @@ class Intro extends Component {
                             type='button'
                             id='enter-button'
                             className='intro__button button button--primary button--pulsate'
-                            onClick={hideIntro}
+                            onClick={onClick}
                         >
                             Find out
                         </button>

--- a/src/app/src/Map.js
+++ b/src/app/src/Map.js
@@ -1,9 +1,5 @@
 import React, { Component } from 'react';
-import ReactMapGL, {
-    NavigationControl,
-    Marker,
-    FlyToInterpolator,
-} from 'react-map-gl';
+import ReactMapGL, { NavigationControl, Marker } from 'react-map-gl';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { connect } from 'react-redux';
 import mapboxgl from 'mapbox-gl';
@@ -27,13 +23,7 @@ class GLMap extends Component {
 
     goToLocation = options => {
         toggleBackToMapButton();
-
-        this.props.updateViewport(
-            Object.assign({}, options, {
-                transitionInterpolator: new FlyToInterpolator(),
-                transitionDuration: 3000,
-            })
-        );
+        this.props.updateViewport(options);
     };
 
     renderCityMarkers = (sensor, index) => {
@@ -62,6 +52,12 @@ class GLMap extends Component {
     };
 
     render() {
+        const markers = this.props.areMarkersVisible
+            ? Object.values(this.props.sensors.features).map(
+                  this.renderCityMarkers
+              )
+            : null;
+
         return (
             <div id='map' className='map'>
                 <ReactMapGL
@@ -71,9 +67,7 @@ class GLMap extends Component {
                     height={'100%'}
                     width={'100%'}
                     mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_API_KEY}
-                    mapStyle={
-                        'mapbox://styles/azavea/cjrky7g714qpy2spmyk5u9llq'
-                    }
+                    mapStyle={this.props.style}
                     interactive={false}
                     doubleClickZoom={false}
                     dragPan={false}
@@ -84,9 +78,7 @@ class GLMap extends Component {
                     attributionControl={false}
                 >
                     <NavigationControl showZoom={false} />
-                    {Object.values(this.props.sensors.features).map(
-                        this.renderCityMarkers
-                    )}
+                    {markers}
                 </ReactMapGL>
                 {this.props.showBackToMapButton ? (
                     <BackToMapButton handleOnClick={this.goToLocation} />
@@ -99,6 +91,8 @@ class GLMap extends Component {
 function mapStateToProps(state) {
     return {
         mapstate: state.map.viewport,
+        areMarkersVisible: state.map.areMarkersVisible,
+        style: state.map.style,
         showBackToMapButton: state.map.isBackToMapButtonVisible,
         sensors: state.app.sensors,
         sensorRatings: state.app.sensorRatings,

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -73,3 +73,23 @@ export const msPerDay = msPerHour * 24;
 export const msPerWeek = msPerDay * 7;
 export const msPerMonth = msPerDay * 30; // roughly a month, 30 days
 export const msPerYear = msPerWeek * 52;
+
+export const mapOverviewViewport = Object.freeze({
+    zoom: 9,
+    bearing: -30,
+    pitch: 60,
+    latitude: 40.2161,
+    longitude: -75.0726,
+    transitionDuration: 1500,
+});
+
+export const initialMapViewport = Object.freeze({
+    zoom: 8,
+    bearing: -25,
+    pitch: 0,
+    latitude: 40.2161,
+    longitude: -75.0726,
+});
+
+export const primaryMapStyle =
+    'mapbox://styles/azavea/cjrky7g714qpy2spmyk5u9llq';

--- a/src/app/src/map.actions.js
+++ b/src/app/src/map.actions.js
@@ -1,6 +1,13 @@
 import { createAction } from 'redux-act';
+import { FlyToInterpolator } from 'react-map-gl';
 
 export const toggleBackToMapButton = createAction(
     'Toggle back to map button visibility'
 );
-export const updateViewport = createAction('Update map viewport');
+export const updateViewport = createAction('Update map viewport', options =>
+    Object.assign({}, options, {
+        transitionInterpolator: new FlyToInterpolator(),
+        transitionDuration: 2000,
+    })
+);
+export const showMarkers = createAction('Show markers');

--- a/src/app/src/map.reducers.js
+++ b/src/app/src/map.reducers.js
@@ -1,19 +1,21 @@
 import { createReducer } from 'redux-act';
 import update from 'immutability-helper';
 
-import { toggleBackToMapButton, updateViewport } from './map.actions';
+import {
+    toggleBackToMapButton,
+    updateViewport,
+    showMarkers,
+} from './map.actions';
+
+import { primaryMapStyle, initialMapViewport } from './constants';
 
 // Map-related state
 export const initialMapState = {
     isBackToMapButtonVisible: false,
+    areMarkersVisible: false,
+    style: primaryMapStyle,
     // State specific to and required by MapBoxGL
-    viewport: {
-        latitude: 40.2161,
-        longitude: -75.0726,
-        zoom: 9,
-        bearing: -30,
-        pitch: 60,
-    },
+    viewport: initialMapViewport,
 };
 
 // Map-related reducer
@@ -29,6 +31,12 @@ const mapReducer = createReducer(
             update(state, {
                 viewport: {
                     $merge: payload,
+                },
+            }),
+        [showMarkers]: (state, payload) =>
+            update(state, {
+                areMarkersVisible: {
+                    $set: true,
                 },
             }),
     },

--- a/src/app/src/sass/06_components/_map.scss
+++ b/src/app/src/sass/06_components/_map.scss
@@ -24,6 +24,21 @@
   margin: 0!important;
 }
 
+.p-intro {
+  .mapboxgl-ctrl-bottom-right {
+    display: none;
+  }
+
+  .mapboxgl-ctrl-bottom-left {
+    bottom: 10px;
+    left: 10px;
+  }
+
+  .mapboxgl-ctrl-icon.mapboxgl-ctrl-compass {
+    display: none;
+  }
+}
+
 .p-landing {
   .mapboxgl-ctrl-bottom-left {
     bottom: 50px;

--- a/src/app/src/sass/07_layouts/_intro.scss
+++ b/src/app/src/sass/07_layouts/_intro.scss
@@ -1,11 +1,7 @@
 .p-intro {
     border: 10px solid $brand-orange;
-    background-color: $brand-green-dark;
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
+    height: 100vh;
+    width: 100vw;
 
     .l-landing {
         display: none;


### PR DESCRIPTION
## Overview

Implements a transition from the intro screen to the home screen, as shown in the prototype, via the following changes:

- The background fill on the intro screen was eliminated so that the map is visible.
- A new map style was created for the intro screen that does not have any labels. When transitioning, this style is swapped out for the style with the labels.
- The sensor markers are only added to the map after the "Find out" button is clicked.
- The map pitch is adjusted as the transition is happening.

Additionally, the style of the intro screen was adjusted to remove a "hiccup" when transitioning to the home screen style due to use of absolute positioning.

Connects #82 

### Demo

Due to the map style, GIFs are very large and can't be uploaded to Github. Check out the Netlify deploy preview.

## Testing Instructions

- Visit the app, and verify the intro screen map meets the conditions described in the issue.
- Click the "Find out" button, and verify the map transitions, the markers are added, and the map labels are displayed.