### PR TITLE
Make various sensor related updates

### DIFF
--- a/src/app/src/app.actions.js
+++ b/src/app/src/app.actions.js
@@ -8,6 +8,8 @@ import {
     transformSensorDataToRatings,
 } from './sensorUtils';
 
+import { DEFAULT_SENSOR_DATA } from './constants';
+
 export const hideIntro = createAction('Hide intro screen');
 export const selectSensor = createAction('Select sensor');
 export const deselectSensor = createAction('Deselect sensor');
@@ -60,6 +62,9 @@ export function pollSensor(sensor) {
             // The app will always show data, albeit dummy initial data or stale sensor data,
             // if on-going sensor requests fail
             failPollingSensor(e);
+            updateSensorRatings(
+                transformSensorDataToRatings(DEFAULT_SENSOR_DATA[Id])
+            );
         }
     };
 }

--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -46,6 +46,7 @@ export const VARIABLE_CODES = {
 };
 
 export const VARIABLE_WITHIN_HEALTHY_RANGE = 1;
+export const VARIABLE_NEAR_EDGE_OF_HEALTHY_RANGE = 0.5;
 export const VARIABLE_NOT_WITHIN_HEALTHY_RANGE = 0;
 export const RATING_GOOD = 'GOOD';
 export const RATING_FAIR = 'FAIR';

--- a/src/app/src/sensors.json
+++ b/src/app/src/sensors.json
@@ -12,23 +12,23 @@
         "HealthyRanges": {
             "TURBIDITY": {
                 "lower": 0,
-                "upper": 29
+                "upper": 40
             },
             "OXYGEN": {
-                "lower": 5,
-                "upper": 6
+                "lower": 3,
+                "upper": 12
             },
             "PH": {
                 "lower": 6,
-                "upper": 9
+                "upper": 8
             },
             "TEMPERATURE": {
-                "lower": 40,
-                "upper": 87
+                "lower": 32,
+                "upper": 85
             },
             "IBI": {
-                "lower": 0,
-                "upper": 0
+                "lower": 12,
+                "upper": 49
             }
         }
       },
@@ -74,8 +74,8 @@
                 "upper": 87
             },
             "IBI": {
-                "lower": 0,
-                "upper": 0
+                "lower": 13,
+                "upper": 35
             }
         }
       },
@@ -106,23 +106,23 @@
         "HealthyRanges": {
             "TURBIDITY": {
                 "lower": 0,
-                "upper": 29
+                "upper": 3
             },
             "OXYGEN": {
-                "lower": 5,
-                "upper": 6
+                "lower": 6,
+                "upper": 14
             },
             "PH": {
-                "lower": 6,
-                "upper": 9
+                "lower": 6.5,
+                "upper": 8.5
             },
             "TEMPERATURE": {
-                "lower": 40,
-                "upper": 87
+                "lower": 32,
+                "upper": 86
             },
             "IBI": {
-                "lower": 0,
-                "upper": 0
+                "lower": 12,
+                "upper": 99
             }
         }
       },


### PR DESCRIPTION
## Overview

Updates the sensor healthy ranges based on feedback from the client, add fallback to sensor defaults in case of polling error, and add the "fair" calculation to the sensor overall rating logic.

See commit messages for details.

Connects #79 
Connects #69 

### Demo

![image](https://user-images.githubusercontent.com/1042475/62232491-5ab73a80-b394-11e9-928e-1b797bf265f7.png)

## Testing Instructions

- Load the app, visit a sensor, and open the sensor detail modal. 
- Verify the fish symbol for each variable is correct given the variable value and healthy range (outside of range = red, within 10% of edges = yellow, everything else = blue).
- Also verify that for the two failing sensors (Tinicum and Wissahickon), the default data is used.