### PR TITLE
Fix broken scroll

### DIFF
--- a/src/app/src/sass/06_components/_modal.scss
+++ b/src/app/src/sass/06_components/_modal.scss
@@ -36,7 +36,7 @@
     }
 
     &__container {
-        position: absolute;
+        position: relative;
         top: 0;
         left: 50%;
         z-index: 99;


### PR DESCRIPTION
## Overview
This ended up being a quick fix—our modals were `position: absolute;` and needed to be `position: relative;` to have a scrollable height. Why did it ever work on iPads? Good question.

Connects #90

### Demo
Safari
![safari](https://user-images.githubusercontent.com/5672295/62308136-e394ab80-b452-11e9-8b02-8370d9267846.gif)

Firefox
![firefox](https://user-images.githubusercontent.com/5672295/62308143-e7283280-b452-11e9-9354-99b33701f1c6.gif)

### Notes
The fish don't look centered on the Browserstack iPad but do on desktop—I didn't attempt to fix in this issue, since I figure there will be a polish round later.

## Testing Instructions
* `git pull` 
* Enter app, open a site, click the little chart icon in the sidebar
* attempt to scroll
* Ideally try this on an iPad (I used Browserstack, both chrome and safari)
