### PR TITLE
Update last live date

### DIFF
--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -52,11 +52,11 @@ export const RATING_FAIR = 'FAIR';
 export const RATING_POOR = 'POOR';
 export const OVERALL_RATING = 'OVERALL_RATING';
 
-// The selected live sensors last worked on 12/04/2018
-export const LAST_LIVE_SENSOR_DATE = '2018-12-04';
+// The selected live sensors last worked on 08/01/2019
+export const LAST_LIVE_SENSOR_DATE = '2019-08-01';
 
-// Quarterly data was taken for all surveys on or after 8/01/2018
-export const LAST_QUARTERLY_SURVEY_DATE = '2018-08-01';
+// Quarterly data was taken for all surveys on or after 5/28/2019
+export const LAST_QUARTERLY_SURVEY_DATE = '2019-05-28';
 
 export const DEFAULT_SENSOR_DATA = SENSORS.features.reduce(
     (acc, sensor) =>


### PR DESCRIPTION
## Overview

The previous date caused the API to return a 403. It is not clear why, but having a more recent date does not cause the same issue.

Connects #103 

### Notes

This is considered a quick fix to get live data back in the app. Budget permitting, we may need a more dynamic way to detect that last live date. See https://github.com/azavea/ism-watershed-wellness-snapshot/issues/68

## Testing Instructions

- Verify all of the sensor API requests succeed and the sensor data is from today.