### PR TITLE
Convert Celsius to Fahrenheit 

### DIFF
--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -16,6 +16,7 @@ import {
     RATING_POOR,
     LAST_LIVE_SENSOR_DATE,
     LAST_QUARTERLY_SURVEY_DATE,
+    TEMPERATURE,
     msPerHour,
     msPerMonth,
     msPerWeek,
@@ -54,6 +55,10 @@ export function parseCsvString(csvString) {
     return data.data;
 }
 
+export function convertCtoF(tempInC) {
+    return Math.round((tempInC * 9) / 5 + 32);
+}
+
 export function parseRiverGaugeApiData(id, data) {
     // API data sends variable data in the same order mirrored in VARIABLES
     const extractedVariableData = VARIABLES.reduce(
@@ -69,8 +74,16 @@ export function parseRiverGaugeApiData(id, data) {
                         Number(sensorReading.value) !==
                         apiVariableData.variable.noDataValue
                 );
+
+                let sensorValue = Number(sensorReading.value);
+
+                // Convert temp from C to F
+                if (variable === TEMPERATURE) {
+                    sensorValue = convertCtoF(sensorValue);
+                }
+
                 return Object.assign(acc, {
-                    [variable]: Number(sensorReading.value),
+                    [variable]: sensorValue,
                     timestamp: new Date(sensorReading.dateTime),
                 });
             } else {
@@ -104,6 +117,9 @@ export function parseRiverGaugeCsvData(id, data) {
             let variableValue = dataRow[code];
             if (!variableValue) {
                 variableValue = DEFAULT_SENSOR_DATA[id][variable];
+            }
+            if (variable === TEMPERATURE) {
+                variableValue = convertCtoF(variableValue);
             }
             return Object.assign(acc, { [variable]: variableValue });
         },

--- a/src/app/src/sensors.json
+++ b/src/app/src/sensors.json
@@ -42,7 +42,7 @@
       "defaultValues": {
         "OXYGEN": 12.0,
         "PH": 7.0,
-        "TEMPERATURE": 6.0,
+        "TEMPERATURE": 42.8,
         "TURBIDITY": 4.0,
         "id": "01475548",
         "timestamp": 0
@@ -89,7 +89,7 @@
       "defaultValues": {
         "OXYGEN": 10.0,
         "PH": 8.0,
-        "TEMPERATURE": 23.0,
+        "TEMPERATURE": 73.4,
         "TURBIDITY": 0,
         "id": "01474000",
         "timestamp": 0
@@ -136,7 +136,7 @@
       "defaultValues": {
         "OXYGEN": 12.1,
         "PH": 7.4,
-        "TEMPERATURE": 16.0,
+        "TEMPERATURE": 60.8,
         "TURBIDITY": 4.0,
         "id": "01438500",
         "timestamp": 0


### PR DESCRIPTION
## Overview

The healthy ranges were provided in Fahrenheit, but the sensor data is provided in Celsius. Convert to Fahrenheit for calculation and display purposes in the app.

Also, at the moment, we only have 4 variables per sensor instead of 5. The overall rating calculation was designed for 5 variables. Modify it for 4 until IBI is added.

Connects #109 

### Demo

![image](https://user-images.githubusercontent.com/1042475/62792446-4e6e6400-ba9d-11e9-81bb-c57f42b2fe20.png)

## Testing Instructions

- Visit the sensors, and verify the temperature is displayed in Fahrenheit, and that the temperature healthy range calculation is resulting in the correct fish color.