### PR TITLE
Add in client Typekit embed link

### DIFF
--- a/src/app/src/sass/01_settings/_type.scss
+++ b/src/app/src/sass/01_settings/_type.scss
@@ -1,4 +1,4 @@
-$font-url: 'https://use.typekit.net/vth2uon.css';
+$font-url: 'https://use.typekit.net/vyl4wmw.css';
 
 $font-family: 'filson-soft', sans-serif;
 


### PR DESCRIPTION
## Overview
We were linking to a font hosted on Azavea's account. This PR adds in the client's embed link.

Connects #32

### Demo
![Screen Shot 2019-08-13 at 2 09 15 PM](https://user-images.githubusercontent.com/5672295/62965926-fbb1e680-bdd3-11e9-87bf-4801663e8222.png)


### Notes
I turned off the downloaded versions of the font on my machine and it seemed to work... but we should definitely make sure it works on Netlify and someone else's computer. 


## Testing Instructions
* `git pull`
* View the website and ensure that fonts look right (feel free to send me a screenshot so I can confirm)
