### PR TITLE
Feature/al/polish

### DIFF
--- a/src/app/src/App.js
+++ b/src/app/src/App.js
@@ -37,7 +37,7 @@ class App extends Component {
         let containerClassName = isIntroVisible
             ? 'main p-intro'
             : selectedSensor
-            ? 'main p-detail'
+            ? `main p-detail detail--${selectedSensor.properties.Location.split(" ").join("-").toLowerCase()}`
             : 'main p-landing';
         if (isSensorModalDisplayed) {
             containerClassName += ' modal-is-open';

--- a/src/app/src/SensorOverview.js
+++ b/src/app/src/SensorOverview.js
@@ -12,7 +12,7 @@ export default function SensorOverview({
     isSensorModalDisplayed,
 }) {
     return (
-        <div className='main l-detail l-detail--tinicum'>
+        <div className='main l-detail'>
             <div className='sidebar'>
                 <div className='sidebar__content'>
                     <header className='sidebar__header'>

--- a/src/app/src/img/bubbles.svg
+++ b/src/app/src/img/bubbles.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="61px" height="65px" viewBox="0 0 61 65" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <title>bubbles</title>
+    <g id="bubbles" transform="translate(9.000000, 21.000000)" fill="#FFFFFF">
+        <circle id="bubble-6" cx="11.5" cy="2.5" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" from="2.5" to="30" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" from="11.5" to="-20" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" attributeName="opacity" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+        <circle id="bubble-5" cx="18.5" cy="54.5" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" from="18.5" to="105" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" from="54.5" to="-30" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" attributeName="opacity" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+        <circle id="bubble-4" cx="12.5" cy="30" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" from="12.5" to="80" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" from="30" to="-30" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" attributeName="opacity" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+        <circle id="bubble-3" cx="-4.5" cy="40" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" from="-4.5" to="30" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" from="40" to="10" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" attributeName="opacity" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+        <circle id="bubble-1" cx="0" cy="9.5" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" from="0" to="40" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" from="9.5" to="-10" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" attributeName="opacity" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+
+        <!-- Delayed animated bubbles -->
+        <circle id="bubble-7" cx="-40" cy="70" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" begin="1s" from="-40" to="40" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" begin="1s" from="70" to="-30" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" begin="1s" attributeName="opacity" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+        <circle id="bubble-8" cx="-4.5" cy="50" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" begin="1s" from="-4.5" to="30" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" begin="1s" from="50" to="10" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" attributeName="opacity" begin="1s" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+        <circle id="bubble-9" cx="30" cy="10" r="2.5" opacity="0">
+            <animate attributeType="XML" attributeName="cx" begin="1s" from="30" to="80" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="XML" attributeName="cy" begin="1s" from="10" to="-30" dur="2.5s" repeatCount="indefinite"/>
+            <animate attributeType="CSS" attributeName="opacity" begin="1s" from="0" to="1" dur="2.5s" repeatCount="indefinite"/>
+        </circle>
+    </g>
+</svg>

--- a/src/app/src/img/compass.svg
+++ b/src/app/src/img/compass.svg
@@ -4,9 +4,20 @@
     <title>Compass</title>
     <desc>Created with Sketch.</desc>
     <g id="Designs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <filter id="dropshadow" height="130%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="4"/> <!-- stdDeviation is how much to blur -->
+            <feOffset dx="1" dy="1" result="offsetblur"/> <!-- how much to offset -->
+            <feComponentTransfer>
+               <feFuncA type="linear" slope="1"/> <!-- slope is the opacity of the shadow -->
+            </feComponentTransfer>
+            <feMerge>
+               <feMergeNode/> <!-- this contains the offset blurred image -->
+               <feMergeNode in="SourceGraphic"/> <!-- this contains the element that the filter is applied to -->
+            </feMerge>
+        </filter>
         <g id="Home" transform="translate(-1280.000000, -894.000000)" fill-rule="nonzero">
-            <g id="Compass" transform="translate(1273.000000, 887.000000)">
-                <circle id="Oval" fill="#14352D" cx="32.5" cy="32.5" r="24.5"></circle>
+            <g id="Compass" transform="translate(1273.000000, 887.000000)" style="filter:url(#dropshadow)">
+                <circle id="Oval" cx="32.5" cy="32.5" r="24.5"></circle>
                 <path d="M32.5,58 C18.4167389,58 7,46.5832611 7,32.5 C7,18.4167389 18.4167389,7 32.5,7 C46.5832611,7 58,18.4167389 58,32.5 C58,46.5832611 46.5832611,58 32.5,58 Z M32.5,56 C45.4786916,56 56,45.4786916 56,32.5 C56,19.5213084 45.4786916,9 32.5,9 C19.5213084,9 9,19.5213084 9,32.5 C9,45.4786916 19.5213084,56 32.5,56 Z" id="Oval" fill="#D2ECEE"></path>
                 <g id="Group-5" transform="translate(32.853553, 33.353553) rotate(-315.000000) translate(-32.853553, -33.353553) translate(9.853553, 10.353553)">
                     <g id="compass" transform="translate(0.221825, 0.000000)" fill="#D2ECEE">

--- a/src/app/src/img/compass.svg
+++ b/src/app/src/img/compass.svg
@@ -4,7 +4,7 @@
     <title>Compass</title>
     <desc>Created with Sketch.</desc>
     <g id="Designs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <filter id="dropshadow" height="130%">
+        <filter id="dropshadow" height="130%" filterRes="1200">
             <feGaussianBlur in="SourceAlpha" stdDeviation="4"/> <!-- stdDeviation is how much to blur -->
             <feOffset dx="1" dy="1" result="offsetblur"/> <!-- how much to offset -->
             <feComponentTransfer>

--- a/src/app/src/img/compass_alt.svg
+++ b/src/app/src/img/compass_alt.svg
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="51px" height="51px" viewBox="0 0 51 51" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 53.2 (72643) - https://sketchapp.com -->
+    <title>Compass</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Designs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" style="filter:url(#dropshadow)">
+        <filter id="dropshadow" height="130%">
+            <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="DROP"/> <!-- stdDeviation is how much to blur -->
+
+            <!-- flood the region with a ligh grey color; we'll name this layer "COLOR" -->
+            <feFlood flood-color="#0d332c" result="COLOR"></feFlood>
+
+            <!-- Composite the DROP and COLOR layers together to colorize the shadow. The result is named "SHADOW"  -->
+            <feComposite in="COLOR" in2="DROP" operator="in" result="DROPSHADOW"></feComposite>
+
+            <feMerge>
+                <feMergeNode in="DROPSHADOW"></feMergeNode>
+                <feMergeNode in="SourceGraphic"></feMergeNode>
+            </feMerge>
+        </filter>
+        <g id="Home" transform="translate(-1280.000000, -894.000000)" fill-rule="nonzero">
+            <g id="Compass" transform="translate(1273.000000, 887.000000)">
+                <circle id="Oval" cx="32.5" cy="32.5" r="24.5"></circle>
+                <path d="M32.5,58 C18.4167389,58 7,46.5832611 7,32.5 C7,18.4167389 18.4167389,7 32.5,7 C46.5832611,7 58,18.4167389 58,32.5 C58,46.5832611 46.5832611,58 32.5,58 Z M32.5,56 C45.4786916,56 56,45.4786916 56,32.5 C56,19.5213084 45.4786916,9 32.5,9 C19.5213084,9 9,19.5213084 9,32.5 C9,45.4786916 19.5213084,56 32.5,56 Z" id="Oval" fill="#ffffff"></path>
+                <g id="Group-5" transform="translate(32.853553, 33.353553) rotate(-315.000000) translate(-32.853553, -33.353553) translate(9.853553, 10.353553)">
+                    <g id="compass" transform="translate(0.221825, 0.000000)" fill="#ffffff">
+                        <polygon id="Triangle" transform="translate(14.500000, 15.221825) rotate(-45.000000) translate(-14.500000, -15.221825) " points="14.5 4.22182541 22 26.2218254 7 26.2218254"></polygon>
+                        <path d="M28.7216619,23 L22.2781746,4.09910381 L15.8346873,23 L22.2781746,41.9008962 L28.7216619,23 Z M30.7246848,23.3226739 L23.2246848,45.3226739 C22.9168093,46.2257754 21.6395399,46.2257754 21.3316644,45.3226739 L13.8316644,23.3226739 C13.7603447,23.1134693 13.7603447,22.8865307 13.8316644,22.6773261 L21.3316644,0.677326072 C21.6395399,-0.225775357 22.9168093,-0.225775357 23.2246848,0.677326072 L30.7246848,22.6773261 C30.7960045,22.8865307 30.7960045,23.1134693 30.7246848,23.3226739 Z" id="Combined-Shape" transform="translate(22.278175, 23.000000) rotate(-45.000000) translate(-22.278175, -23.000000) "></path>
+                    </g>
+                    <circle id="Oval" fill="#ffffff" cx="22.5" cy="23.5" r="2.5"></circle>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/src/app/src/img/compass_alt.svg
+++ b/src/app/src/img/compass_alt.svg
@@ -4,7 +4,7 @@
     <title>Compass</title>
     <desc>Created with Sketch.</desc>
     <g id="Designs" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" style="filter:url(#dropshadow)">
-        <filter id="dropshadow" height="130%">
+        <filter id="dropshadow" height="130%" filterRes="1200">
             <feGaussianBlur in="SourceAlpha" stdDeviation="2" result="DROP"/> <!-- stdDeviation is how much to blur -->
 
             <!-- flood the region with a ligh grey color; we'll name this layer "COLOR" -->

--- a/src/app/src/img/de_river_basin.svg
+++ b/src/app/src/img/de_river_basin.svg
@@ -3,7 +3,7 @@
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 311.05 755.56" style="enable-background:new 0 0 311.05 755.56;" xml:space="preserve">
 <defs>
-    <filter id="shadow">
+    <filter id="shadow" filterRes="1200">
         <feDropShadow dx="0" dy="0" stdDeviation="10"/>
     </filter>
 </defs>

--- a/src/app/src/img/info.svg
+++ b/src/app/src/img/info.svg
@@ -1,1 +1,14 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 512" fill="#003845"><path d="M20 424.229h20V279.771H20c-11.046 0-20-8.954-20-20V212c0-11.046 8.954-20 20-20h112c11.046 0 20 8.954 20 20v212.229h20c11.046 0 20 8.954 20 20V492c0 11.046-8.954 20-20 20H20c-11.046 0-20-8.954-20-20v-47.771c0-11.046 8.954-20 20-20zM96 0C56.235 0 24 32.235 24 72s32.235 72 72 72 72-32.235 72-72S135.764 0 96 0z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="white">
+    <filter id="dropshadow" height="130%">
+        <feGaussianBlur in="SourceAlpha" stdDeviation="4"/> <!-- stdDeviation is how much to blur -->
+        <feOffset dx="1" dy="1" result="offsetblur"/> <!-- how much to offset -->
+        <feComponentTransfer>
+           <feFuncA type="linear" slope="1"/> <!-- slope is the opacity of the shadow -->
+        </feComponentTransfer>
+        <feMerge>
+           <feMergeNode/> <!-- this contains the offset blurred image -->
+           <feMergeNode in="SourceGraphic"/> <!-- this contains the element that the filter is applied to -->
+        </feMerge>
+    </filter>
+    <path style="filter:url(#dropshadow)" d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"/>
+</svg>

--- a/src/app/src/img/info.svg
+++ b/src/app/src/img/info.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="white">
-    <filter id="dropshadow" height="130%">
+    <filter id="dropshadow" height="130%" filterRes="1200">
         <feGaussianBlur in="SourceAlpha" stdDeviation="4"/> <!-- stdDeviation is how much to blur -->
         <feOffset dx="1" dy="1" result="offsetblur"/> <!-- how much to offset -->
         <feComponentTransfer>

--- a/src/app/src/sass/01_settings/_type.scss
+++ b/src/app/src/sass/01_settings/_type.scss
@@ -19,6 +19,7 @@ $font-sizes: (
     500: 2.9rem,
     600: 4rem,
     700: 5.1rem,
+    800: 5.8rem,
 );
 
 $text-settings: (
@@ -98,6 +99,14 @@ $heading-settings: (
         color: map-get($font-colors, dark),
         font-weight: map-get($font-weights, bold),
         font-size: map-get($font-sizes, 700),
+        line-height: 1.2,
+        text-transform: uppercase,
+        letter-spacing: 2px
+    ),
+    800: (
+        color: map-get($font-colors, dark),
+        font-weight: map-get($font-weights, bold),
+        font-size: map-get($font-sizes, 800),
         line-height: 1.2,
         text-transform: uppercase,
         letter-spacing: 2px

--- a/src/app/src/sass/01_settings/_type.scss
+++ b/src/app/src/sass/01_settings/_type.scss
@@ -18,7 +18,7 @@ $font-sizes: (
     400: 2.2rem,
     500: 2.9rem,
     600: 4rem,
-    700: 5.6rem,
+    700: 5.1rem,
 );
 
 $text-settings: (

--- a/src/app/src/sass/05_base/_base.scss
+++ b/src/app/src/sass/05_base/_base.scss
@@ -7,11 +7,15 @@
     box-sizing: inherit;
 }
 
-html {
-    box-sizing: border-box;
+html, body, #root, #root > div {
     width: 100%;
     height: 100%;
-    overflow: hidden;
+    padding: 0;
+    margin: 0;
+}
+
+html {
+    box-sizing: border-box;
     color: $black;
     font-size: 62.5%;
 }
@@ -19,8 +23,6 @@ html {
 body {
     @include text();
 
-    width: 100%;
-    height: 100%;
     overflow: auto;
 }
 

--- a/src/app/src/sass/06_components/_banner.scss
+++ b/src/app/src/sass/06_components/_banner.scss
@@ -2,6 +2,7 @@
     position: fixed;
     top: 0;
     left: 50%;
+    margin-top: -100%;
     background: $brand-aqua-light;
     border-radius: 0 0 3rem 3rem;
     transform: translateX(-50%);

--- a/src/app/src/sass/06_components/_button-back.scss
+++ b/src/app/src/sass/06_components/_button-back.scss
@@ -34,7 +34,7 @@
 
     }
 
-    &:active {
+    &:hover {
         .button-back__image {
             transform: scale(1.05);
             opacity: 1;

--- a/src/app/src/sass/06_components/_button.scss
+++ b/src/app/src/sass/06_components/_button.scss
@@ -39,7 +39,7 @@
             border-radius: 6rem;
             content: "";
             mix-blend-mode: multiply;
-            animation: pulsate 2s ease-in infinite;
+            animation: pulsate 2s 0.01s ease-in infinite;
         }
 
         &::after {

--- a/src/app/src/sass/06_components/_footer.scss
+++ b/src/app/src/sass/06_components/_footer.scss
@@ -4,6 +4,7 @@
     bottom: 0;
     left: 0;
     background: $black;
+    margin-bottom: -100%;
     z-index: 1;
 
     &__content {

--- a/src/app/src/sass/06_components/_indicator-reading.scss
+++ b/src/app/src/sass/06_components/_indicator-reading.scss
@@ -1,12 +1,13 @@
 .indicator-reading {
     position: relative;
+    width: 50%;
 
     &__fish {
         position: absolute;
         top: 40%;
         left: 50%;
         transform: translateX(-50%) translateY(-50%);
-        animation: fishBouncing 2s ease-in infinite;
+        animation: fishBouncing 2s 0.01s ease-in infinite;
     }
 
     &__reading {

--- a/src/app/src/sass/06_components/_indicator-reading.scss
+++ b/src/app/src/sass/06_components/_indicator-reading.scss
@@ -7,7 +7,7 @@
         top: 40%;
         left: 50%;
         transform: translateX(-50%) translateY(-50%);
-        animation: fishBouncing 2s 0.01s ease-in infinite;
+        animation: fishBouncing 2s 0.25s ease-in infinite;
     }
 
     &__reading {

--- a/src/app/src/sass/06_components/_intro.scss
+++ b/src/app/src/sass/06_components/_intro.scss
@@ -16,7 +16,7 @@
     }
 
     &__heading {
-        @include heading(700, $color: white, $inverted: true);
+        @include heading(800, $color: white, $inverted: true);
 
         margin-bottom: $pad-comfortable;
     }

--- a/src/app/src/sass/06_components/_map.scss
+++ b/src/app/src/sass/06_components/_map.scss
@@ -22,7 +22,6 @@
   background-size: 50px;
   background-position: center;
   margin: 0!important;
-
 }
 
 .p-intro {

--- a/src/app/src/sass/06_components/_map.scss
+++ b/src/app/src/sass/06_components/_map.scss
@@ -16,12 +16,13 @@
 }
 
 .mapboxgl-ctrl-icon.mapboxgl-ctrl-compass > .mapboxgl-ctrl-compass-arrow {
-  width: 30px!important;
-  height: 30px!important;
+  width: 50px!important;
+  height: 50px!important;
   background-image: url('../img/compass.svg')!important;
-  background-size: 25px;
+  background-size: 50px;
   background-position: center;
   margin: 0!important;
+
 }
 
 .p-intro {
@@ -54,8 +55,8 @@
   }
 
   .mapboxgl-ctrl-compass {
-    top: 15px;
-    right: 20px;
+    top: 20px;
+    right: 45px;
   }
 }
 
@@ -74,7 +75,7 @@
   }
 
   .mapboxgl-ctrl-compass {
-    top: 10px;
-    left: 46%;
+    top: 20px;
+    right: 50.5%;
   }
 }

--- a/src/app/src/sass/06_components/_map.scss
+++ b/src/app/src/sass/06_components/_map.scss
@@ -31,8 +31,11 @@
   }
 
   .mapboxgl-ctrl-bottom-left {
-    bottom: 10px;
-    left: 10px;
+    bottom: 20px;
+
+    // Our wrapper library doesn't support moving this in in the Mapbox API
+    right: 25px;
+    left: auto;
   }
 
   .mapboxgl-ctrl-icon.mapboxgl-ctrl-compass {
@@ -45,13 +48,14 @@
     bottom: 50px;
 
     // Our wrapper library doesn't support moving this in in the Mapbox API
-    right: 20px;
+    right: 25px;
     left: auto;
   }
 
   .mapboxgl-ctrl-bottom-right {
-    bottom: 45px;
-    right: 11rem;
+    bottom: 57px;
+    right: 110px;
+    padding-right: 20px;
   }
 
   .mapboxgl-ctrl-compass {
@@ -65,17 +69,61 @@
     bottom: 5px;
 
     // Our wrapper library doesn't support moving this in in the Mapbox API
-    right: inherit;
-    left: 40%;
+    left: auto;
+    right: 49%;
   }
 
   .mapboxgl-ctrl-bottom-right {
-    left: 38%;
-    right: inherit;
+    bottom: 12px;
+    right: 56.5%;
   }
 
   .mapboxgl-ctrl-compass {
     top: 20px;
     right: 50.5%;
   }
+}
+
+.mapboxgl-ctrl-attrib.mapboxgl-compact {
+    position: relative;
+    height: 20px!important;
+    padding: 0!important;
+    margin: 0!important;
+
+    &::before {
+        content: '';
+        display: block;
+        height: 1.25rem;
+        width: 1px;
+        position: absolute;
+        right: -10px;
+        top: 50%;
+        transform: translateY(-50%);
+        background: white;
+        opacity: 0.5;
+    }
+
+    &::after {
+        background-image: url('../img/info.svg')!important;
+        background-repeat: no-repeat;
+        background-color: transparent!important;
+        opacity: 0.85;
+        width: 20px!important;
+        height: 20px!important;
+        background-size: cover;
+        background-position: center;
+    }
+}
+
+.mapboxgl-ctrl-attrib-inner {
+    background-color: darken($brand-green-dark, 5%);
+    padding: 0.25rem 3rem 0.25rem 0.75rem;
+    border-radius: 4px;
+    -webkit-font-smoothing: antialiased;
+    margin-top: -0.25rem;
+    margin-right: -0.25rem;
+
+    a {
+        color: white!important;
+    }
 }

--- a/src/app/src/sass/06_components/_marker.scss
+++ b/src/app/src/sass/06_components/_marker.scss
@@ -71,6 +71,10 @@
         overflow: hidden;
         border: 2px solid $white;
         border-radius: 50% 50% 50% 0;
+        background-image: url('../img/bubbles.svg')!important;
+        background-blend-mode: overlay;
+        background-size: contain;
+        background-position: center center;
     }
 
     &__level {

--- a/src/app/src/sass/06_components/_marker.scss
+++ b/src/app/src/sass/06_components/_marker.scss
@@ -2,7 +2,7 @@
     position: absolute;
     transform: rotate(-45deg) translateX(0) translateY(0);
     transition: transform 0.25s ease-out;
-    animation: markerBounce 3s ease-in infinite;
+    animation: markerBounce 3s  0.01s ease-in infinite;
 
     &:nth-child(1) {
         animation-delay: 0s;

--- a/src/app/src/sass/06_components/_modal.scss
+++ b/src/app/src/sass/06_components/_modal.scss
@@ -1,5 +1,6 @@
 .modal-is-open {
     overflow: scroll;
+    -webkit-overflow-scrolling: touch;
 
     .main,
     .map {

--- a/src/app/src/sass/07_layouts/_detail.scss
+++ b/src/app/src/sass/07_layouts/_detail.scss
@@ -3,8 +3,8 @@
     height: 100%;
 }
 
-
-.detail--wissahickon {
+.detail--wissahickon,
+.detail--tinicum {
     .mapboxgl-ctrl-icon.mapboxgl-ctrl-compass > .mapboxgl-ctrl-compass-arrow {
         background-image: url('../img/compass_alt.svg')!important;
     }
@@ -14,15 +14,15 @@
             opacity: 1;
         }
     }
-}
 
-.detail--tinicum {
-    .mapboxgl-ctrl-icon.mapboxgl-ctrl-compass > .mapboxgl-ctrl-compass-arrow {
-        background-image: url('../img/compass_alt.svg')!important;
-    }
+    .button-back {
+        &__text {
+            text-shadow:
+                0px 0px 4px rgba($black, 1),
+                1px 1px 8px rgba($black, 1);
+        }
 
-    .mapboxgl-ctrl-attrib.mapboxgl-compact {
-        &::after {
+        &__image {
             opacity: 1;
         }
     }

--- a/src/app/src/sass/07_layouts/_detail.scss
+++ b/src/app/src/sass/07_layouts/_detail.scss
@@ -1,13 +1,5 @@
 .p-detail {
-    .l-landing {
-        display: none;
-    }
-
-    .l-intro {
-        display: none;
-    }
-
-    .l-detail {
-        display: block;
-    }
+    border: 10px solid $brand-orange;
+    width: 100vw;
+    height: 100%;
 }

--- a/src/app/src/sass/07_layouts/_detail.scss
+++ b/src/app/src/sass/07_layouts/_detail.scss
@@ -2,3 +2,28 @@
     width: 100vw;
     height: 100%;
 }
+
+
+.detail--wissahickon {
+    .mapboxgl-ctrl-icon.mapboxgl-ctrl-compass > .mapboxgl-ctrl-compass-arrow {
+        background-image: url('../img/compass_alt.svg')!important;
+    }
+
+    .mapboxgl-ctrl-attrib.mapboxgl-compact {
+        &::after {
+            opacity: 1;
+        }
+    }
+}
+
+.detail--tinicum {
+    .mapboxgl-ctrl-icon.mapboxgl-ctrl-compass > .mapboxgl-ctrl-compass-arrow {
+        background-image: url('../img/compass_alt.svg')!important;
+    }
+
+    .mapboxgl-ctrl-attrib.mapboxgl-compact {
+        &::after {
+            opacity: 1;
+        }
+    }
+}

--- a/src/app/src/sass/07_layouts/_detail.scss
+++ b/src/app/src/sass/07_layouts/_detail.scss
@@ -9,7 +9,5 @@
 
     .l-detail {
         display: block;
-        width: 100vh;
-        height: 100vh;
     }
 }

--- a/src/app/src/sass/07_layouts/_detail.scss
+++ b/src/app/src/sass/07_layouts/_detail.scss
@@ -1,5 +1,4 @@
 .p-detail {
-    border: 10px solid $brand-orange;
     width: 100vw;
     height: 100%;
 }

--- a/src/app/src/sass/07_layouts/_intro.scss
+++ b/src/app/src/sass/07_layouts/_intro.scss
@@ -1,7 +1,7 @@
 .p-intro {
     border: 10px solid $brand-orange;
-    height: 100vh;
     width: 100vw;
+    height: 100%;
 
     .l-landing {
         display: none;
@@ -13,7 +13,5 @@
 
     .l-intro {
         display: block;
-        width: 100vh;
-        height: 100vh;
     }
 }

--- a/src/app/src/sass/07_layouts/_intro.scss
+++ b/src/app/src/sass/07_layouts/_intro.scss
@@ -3,15 +3,7 @@
     width: 100vw;
     height: 100%;
 
-    .l-landing {
-        display: none;
-    }
-
-    .l-detail {
-        display: none;
-    }
-
-    .l-intro {
-        display: block;
+    .footer {
+        margin-bottom: -100%;
     }
 }

--- a/src/app/src/sass/07_layouts/_landing.scss
+++ b/src/app/src/sass/07_layouts/_landing.scss
@@ -1,8 +1,6 @@
 .p-landing {
     .l-landing {
         display: block;
-        width: 100%;
-        height: 100%;
     }
 
     .l-intro {

--- a/src/app/src/sass/07_layouts/_landing.scss
+++ b/src/app/src/sass/07_layouts/_landing.scss
@@ -1,34 +1,9 @@
 .p-landing {
-    .l-landing {
-        display: block;
-    }
-
-    .l-intro {
-        display: none;
-    }
-
-    .l-detail {
-        display: none;
+    .footer {
+        margin-bottom: 0;
     }
 
     .banner {
         margin-top: 0;
     }
 }
-
-/* stylelint-disable selector-max-id */
-#tinicum {
-    top: 60%;
-    left: 20%;
-}
-
-#wissahickon {
-    top: 50%;
-    left: 35%;
-}
-
-#delaware {
-    top: 30%;
-    left: 80%;
-}
-/* stylelint-enable selector-max-id */

--- a/src/app/src/sass/main.scss
+++ b/src/app/src/sass/main.scss
@@ -27,6 +27,6 @@
 @import '06_components/_sidebar.scss';
 @import '06_components/_test.scss';
 
-@import '07_layouts/_detail.scss';
 @import '07_layouts/_intro.scss';
+@import '07_layouts/_detail.scss';
 @import '07_layouts/_landing.scss';

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -209,8 +209,13 @@ export function getFishBackgroundForVariableRating(rating) {
 }
 
 export function getClassNameFromVariableRating(rating) {
-    // TODO #69: Figure out how the warning state is defined
-    return rating === 0 ? 'negative' : 'positive';
+    if (rating === VARIABLE_WITHIN_HEALTHY_RANGE) {
+        return 'positive';
+    } else if (rating === VARIABLE_NOT_WITHIN_HEALTHY_RANGE) {
+        return 'negative';
+    } else {
+        return 'warning';
+    }
 }
 
 export function getFishIconForOverallRating(rating) {


### PR DESCRIPTION
## Overview
Design polish pass of ISM app.

Connects #107

### Demo
![Screen Shot 2019-09-03 at 1 39 31 PM](https://user-images.githubusercontent.com/5672295/64195776-4dd4ad80-ce50-11e9-970e-78506d10bf98.png)

![Screen Shot 2019-09-03 at 3 04 10 PM](https://user-images.githubusercontent.com/5672295/64201335-75317780-ce5c-11e9-83a0-36be669731ad.png)

Enhance contrast of icons on the Tinicum and Wissahickon detail pages, see note
![Screen Shot 2019-09-03 at 3 04 22 PM](https://user-images.githubusercontent.com/5672295/64201336-75317780-ce5c-11e9-947d-d9364de0b008.png)

Bubble animation
![bubbles](https://user-images.githubusercontent.com/5672295/64195619-ecacda00-ce4f-11e9-82a1-4be26ac809f0.gif)

Changing text color for indicators
![Screen Shot 2019-09-03 at 10 49 33 AM](https://user-images.githubusercontent.com/5672295/64201555-f8eb6400-ce5c-11e9-9d64-245d3576cd46.png)
![Screen Shot 2019-09-03 at 10 50 17 AM](https://user-images.githubusercontent.com/5672295/64201556-f8eb6400-ce5c-11e9-86d9-75a5ca660593.png)



### Notes
- Added a "You are here" point for the ISM location. This was in the wireframes, but I forgot to add till now.
- There doesn't appear to be a ton to be done about the contrast of (i) / compass icons -> map background. They're busy satellite tiles, and making the icons black made things worse, so I just made them white and full opacity. Luckily they aren't vital for app usage.
- In screenshots, you'll note that the location labels are in the wrong locations. This should be fixed in the latest published changes, I just didn't update the screenshots.


## Testing Instructions (ideally on Safari/iPad)
- `git pull`
- Click through intro to enter app
- On landing page note bubble animations (these should fade in)
- Tap each marker to see the different sensor pages
- Within each sensor page, tap List icon. You should see centered fish animations (they were sometimes right aligned)
- Tap a (i) anywhere in the app to see the newly styled map links
