### PR TITLE
Text and turbidity rating changes

### DIFF
--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -14,25 +14,25 @@ export const VARIABLE_DETAILS = {
     [TEMPERATURE]: {
         name: 'Water Temperature',
         description:
-            'Water temperature affects the growth and reproduction of living organisms as well as water density.',
+            'Water temperature affects the growth and reproduction of plants and animals in the water.',
         unit: '°F',
     },
     [OXYGEN]: {
         name: 'Dissolved Oxygen',
         description:
-            'A measure of the concentration of oxygen dissolved in a body of water, relative to the maximum concentration.',
+            'Dissolved oxygen is a measure of the concentration of oxygen in a body of water. Plants and animals need oxygen to breath underwater.',
         unit: 'mg/L',
     },
     [PH]: {
         name: 'pH',
         description:
-            'pH is a quantitative measure of the acidity (below 7.0pH) or basicity (above 7.0pH) in a body of water.',
+            'pH tells us how acidic (below 7.0pH) or basic (above 7.0pH) the water is. This determines if the water is healthy enough to support plants and animals.',
         unit: 'pH',
     },
     [TURBIDITY]: {
         name: 'Turbidity',
         description:
-            'Turbidity is a measurement of the cloudiness in a body of water. This cloudiness is caused by the presense of particles that can be invisible to the human eye.',
+            'Turbidity is a measure of the cloudiness of the water. Particles, sediment and pollution may raise turbidity levels.',
         unit: 'NTU',
     },
 };
@@ -53,9 +53,12 @@ export const RATING_FAIR = 'FAIR';
 export const RATING_POOR = 'POOR';
 export const OVERALL_RATING = 'OVERALL_RATING';
 export const RATING_DESCRIPTIONS = Object.freeze({
-    [RATING_GOOD]: 'This means that conditions are ideal for wildlife to thrive. These areas should be protected to preserve this condition.',
-    [RATING_FAIR]: 'This means that conditions are declining. Conditions indicate that wildlife could be becoming stressed. These areas could be restored to GOOD status.',
-    [RATING_POOR]: 'This means that conditions might be harmful to wildlife. The conditions are not normal compared to other surrounding areas. Conditions could be improved through restoration and protection.'
+    [RATING_GOOD]:
+        'This means that conditions are ideal for wildlife to thrive. These areas should be protected to preserve this condition.',
+    [RATING_FAIR]:
+        'This means that conditions are declining. Conditions indicate that wildlife could be becoming stressed. These areas could be restored to GOOD status.',
+    [RATING_POOR]:
+        'This means that conditions might be harmful to wildlife. The conditions are not normal compared to other surrounding areas. Conditions could be improved through restoration and protection.',
 });
 
 // The selected live sensors last worked on 08/01/2019

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -159,14 +159,14 @@ function checkIfVariableNearEdgeOfHealthyRange(
     // of the upper or lower end of the healthy range,
     // except for turbidity, which is only considered fair
     // if it is within 10% of the upper end.
+    const isInUpperTenth = v =>
+        inRangeInclusive(v, upper - (upper - lower) / 10, upper);
+    const isInLowerTenth = v =>
+        inRangeInclusive(v, lower, (upper - lower) / 10 + lower);
     const isVariableNearEdgeOfHealthyRange =
-        (variable !== TURBIDITY &&
-            inRangeInclusive(
-                variableValue,
-                lower,
-                (upper - lower) / 10 + lower
-            )) ||
-        inRangeInclusive(variableValue, upper - (upper - lower) / 10, upper);
+        variable === TURBIDITY
+            ? isInUpperTenth(variableValue)
+            : isInUpperTenth(variableValue) || isInLowerTenth(variableValue);
 
     return isVariableNearEdgeOfHealthyRange;
 }


### PR DESCRIPTION
## Overview

Updates the variable descriptions based on input from the client. Also changes the way "fair" is calculated for turbidity per the client.

Connects #116 

### Demo

**Turbidity rating**
Before:
![image](https://user-images.githubusercontent.com/1042475/72458780-3f4fb880-3797-11ea-85fb-0cf06467edf8.png)

After:
![image](https://user-images.githubusercontent.com/1042475/72458802-4d053e00-3797-11ea-83ef-8bb39b373a8f.png)

## Testing Instructions

- Open one of the sensor panels, and verify the text matches what was provided by the client.
- Open the Wissahickon panel, and verify the Turbidity value, which is currently 0, is consider good and not fair even though it's at the bottom end of the healthy range. 