### PR TITLE
Use special endpoint for waterservices data > 120 days

### DIFF
--- a/src/app/src/constants.js
+++ b/src/app/src/constants.js
@@ -58,11 +58,12 @@ export const RATING_DESCRIPTIONS = Object.freeze({
     [RATING_POOR]: 'This means that conditions might be harmful to wildlife. The conditions are not normal compared to other surrounding areas. Conditions could be improved through restoration and protection.'
 });
 
-// The selected live sensors last worked on 08/01/2019
-export const LAST_LIVE_SENSOR_DATE = '2019-08-01';
+// The nwis.waterservices endpoint was intended for historic data (> 120 days ago)
+// If updating, only use a date > 120 days from the time of writing
+export const LAST_LIVE_SENSOR_DATE = '2019-09-22';
 
-// Quarterly data was taken for all surveys on or after 5/28/2019
-export const LAST_QUARTERLY_SURVEY_DATE = '2019-05-28';
+// Quarterly data was taken for all surveys on or after 08/20/2019
+export const LAST_QUARTERLY_SURVEY_DATE = '2019-08-20';
 
 export const DEFAULT_SENSOR_DATA = SENSORS.features.reduce(
     (acc, sensor) =>

--- a/src/app/src/sensorUtils.js
+++ b/src/app/src/sensorUtils.js
@@ -39,7 +39,7 @@ export function makeRiverGaugeRequest(id, isApiRequest) {
     const cleanedCodes = commaSeparatedCodes.slice(0, -1);
 
     const url = isApiRequest
-        ? `https://waterservices.usgs.gov/nwis/iv/?format=json&sites=${id}&param=${cleanedCodes}&startDT=${LAST_LIVE_SENSOR_DATE}`
+        ? `https://nwis.waterservices.usgs.gov/nwis/iv/?format=json&sites=${id}&param=${cleanedCodes}&startDT=${LAST_LIVE_SENSOR_DATE}`
         : `https://nwis.waterdata.usgs.gov/nwis/qwdata/?site_no=${id}&agency_cd=USGS&inventory_output=retrieval&rdb_inventory_output=value&begin_date=${LAST_QUARTERLY_SURVEY_DATE}&TZoutput=0&pm_cd_compare=Greater%20than&radio_parm_cds=all_parm_cds&qw_attributes=0&format=rdb&qw_sample_wide=wide&rdb_qw_attributes=0&date_format=YYYY-MM-DD&rdb_compression=value&submitted_form=brief_list`;
     return axios.get(url);
 }


### PR DESCRIPTION
## Overview

We were seeing failing requests (`403` error code) to the waterservices API. Upon investigation of USGS documentation, local testing, and talking with IT at USGS, we now know that requests for data from the waterservices API older than 120 days should be requested from the url prefixed 'nwis'. Otherwise, the request gets redirected to a different origin (waterservices to nwis.waterservices) and the app encounters CORS issues in the browser. The CORS failure is sneakily masquerading as the `403`.

In discussion with USGS, we clarified some other details that I'll note here:
- There is no rate limiting on these endpoints
- There is no combination of params to pull most recent data
We'd have to provide some time band through `startDate`, `period` and/or `modifiedSince`. `modifiedSince` looks promising at a glance but it's not actually different in usage than the other options, in terms of becoming stale. 
- Pulling "too much" data should not break the request

### Demo

<img width="499" alt="Screen Shot 2020-01-16 at 2 24 16 PM" src="https://user-images.githubusercontent.com/10568752/72556307-57453c00-386c-11ea-981d-834d2a713fd2.png">

Using the un-prefixed URL:
<img width="475" alt="Screen Shot 2020-01-16 at 2 24 34 PM" src="https://user-images.githubusercontent.com/10568752/72556308-57453c00-386c-11ea-8d1a-935b0fcbe3e0.png">


## Testing Instructions

Open the netlify build on this PR. Refresh wildly and ensure the API requests come back successfully each time.
